### PR TITLE
Integrate an 'OTA' build command into the FHC tool.

### DIFF
--- a/doc/ota.md
+++ b/doc/ota.md
@@ -1,0 +1,17 @@
+fhc-ota -- Build OTA version of an app
+============================================
+
+## SYNOPSIS
+
+    fhc ota app=<appId> destination=<destination> version=<version> config=<config> keypass=<private key password> certpass=<certificate password>
+      where <destination> is one of: andriod, iphone
+      where <version> is specific to the destination, see http://www.feedhenry.com/TODO
+      where <config> is either 'distribution' or 'release'
+      'keypass' and 'certpass' only needed for 'release' builds
+    
+## DESCRIPTION
+
+This command can be used to return the OTA installer URL of a Feedhenry application. To function, you must have an 'In-House' distribution certificate installed in the Feedhenry Studio. This command returns both the OTA install URL and a corresponding convenience short URL.
+
+e.g. 
+fhc ota app=mfLkParVTDcr80-uEk8OhEfT destination=iphone config=distribution keypass=password certpass= version=4.0

--- a/lib/fhc.js
+++ b/lib/fhc.js
@@ -64,6 +64,7 @@ var commandCache = {}
               ,'act'
               ,'apps'
               ,'build'
+              ,'ota'
               ,'fhcfg'
               ,'completion'
               ,'configuration'

--- a/lib/ota.js
+++ b/lib/ota.js
@@ -1,0 +1,42 @@
+module.exports = ota;
+
+var fhreq = require("./utils/request");
+
+ota.usage = "\nfhc ota app=<appId> destination=<destination> version=<version> config=<config> keypass=<private key password> certpass=<certificate password>"
+  + "\nwhere <destination> is one of: andriod, iphone, ipad, blackberry, windowsphone7"
+  + "\nwhere <version> is specific to the destination, see supported destinations here: http://www.feedhenry.com/TODO"
+  + "\nwhere <config> is always distribution or release for OTA"
+  + "\n'keypass' and 'certpass' only needed for 'release' builds";
+
+var build = require('./build.js');
+var request = require('request');
+
+// main build entry point
+function ota (args, cb) {
+  try{
+    build(args, function(err, res){
+      if (err){
+        return cb(err);
+      }
+      if (res && res.length && res[0] && res[0].length && res[0][0].action){ // the response is strangely nested arrays - 
+        var url = res[0][0].action.url;
+        url = url.replace(/\/[a-zA-Z]+~.+~/g,'/'); // Strip the platform~osVersion~versionNum string
+        url = url.replace('.zip','.plist'); // Make the zip a plist instead!
+        url = "http://ota.feedhenry.com/ota/ios.html?url=" + url; // Now, throw the plist over to the ota server
+        
+
+        shortenerRequestBody = {
+            "longUrl": url
+        };
+        
+        request({uri: 'https://www.googleapis.com/urlshortener/v1/url', method: 'POST', json: shortenerRequestBody}, function (err, response, body) {
+          var shortUrl = body.id.replace("\\","");
+          cb(undefined, 'OTA URL: ' + url  + '\nShort URL: ' + shortUrl);
+        });
+               
+      }
+    });
+  }catch (x) {
+    return cb("Error processing args: " + x + "\nUsage: " + ota.usage);
+  }
+};

--- a/man1/ota.1
+++ b/man1/ota.1
@@ -1,0 +1,25 @@
+.\" Generated with Ronnjs 0.3.8
+.\" http://github.com/kapouer/ronnjs/
+.
+.TH "FHC\-OTA" "1" "November 2011" "" ""
+.
+.SH "NAME"
+\fBfhc-ota\fR \-\- Build OTA version of an app
+.
+.SH "SYNOPSIS"
+.
+.nf
+fhc ota app=<appId> destination=<destination> version=<version> config=<config> keypass=<private key password> certpass=<certificate password>
+  where <destination> is one of: andriod, iphone
+  where <version> is specific to the destination, see http://www\.feedhenry\.com/TODO
+  where <config> is either \'distribution\' or \'release\'
+  \'keypass\' and \'certpass\' only needed for \'release\' builds
+.
+.fi
+.
+.SH "DESCRIPTION"
+This command can be used to return the OTA installer URL of a Feedhenry application\. To function, you must have an \'In\-House\' distribution certificate installed in the Feedhenry Studio\. This command returns both the OTA install URL and a corresponding convenience short URL\.
+.
+.P
+e\.g\. 
+fhc ota app=mfLkParVTDcr80\-uEk8OhEfT destination=iphone config=distribution keypass=password certpass= version=4\.0


### PR DESCRIPTION
Integrate an 'OTA' command, which uses the build cmd, transforms into an OTA installer URL, then url-shortens
