### PR TITLE
Allow FHC Files update to receive file contents as a param

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -57,16 +57,31 @@ function read (fileId, cb) {
 
 function update (appId, fileId, file, cb){
   if (!fileId) return cb("No fileId specified! Usage:\n" + files.usage);
-
-  fs.readFile(file, encoding='utf8', function(er, data) {
-    if (er) {
-      log.error("File not found: " + er);
+  if (!file) return cb("No file specified! Usage:\n" + files.usage);
+  var apiURL = "box/srv/1.1/ide/" + fhc.domain + "/file/update";
+  if (typeof file==="string"){
+    // If type is string, we're using fs to take contents from a filename
+    fs.readFile(file, encoding='utf8', function(er, data) {
+      if (er) {
+        log.error("File not found: " + er);
+        return cb(er);
+      }else {
+        var payload = {files:[{guid: fileId,contents:data}],appId:appId};
+        common.doApiCall(fhreq.getFeedHenryUrl(), apiURL, payload, "Error updating file: ", cb);
+      }
+    });  
+  }else{
+    // If not, it's an object and should have a .fileContents
+    if (file.fileContents){
+      var payload = {files:[{guid: fileId,contents:file.fileContents}],appId:appId};
+      common.doApiCall(fhreq.getFeedHenryUrl(), apiURL, payload, "Error updating file: ", cb);
+    }else{
+      var er = "No file contents specified.";
+      log.error(er);
       return cb(er);
-    }else {
-      var payload = {files:[{guid: fileId,contents:data}],appId:appId};
-      common.doApiCall(fhreq.getFeedHenryUrl(), "box/srv/1.1/ide/" + fhc.domain + "/file/update", payload, "Error updating file: ", cb);
     }
-  });
+  }
+  
 };
 
 function create (appId, path, name, fileType, cb){


### PR DESCRIPTION
Allow fhc files update to pass the file contents as a string, rather than a filename followed by file IO. Achieved by passing an object rather than a filename. 
This is currently undocumented, as it's intended as something to allow fh-studio (which consumes FHC as a module) to perform file saves.
Documentation could be added, but I think it best to wait until FHC has a more widespread approach to allowing it's consumption as a module? 
