### PR TITLE
Part of ticket 3097, fh-db has been removed as a dependancy from fh-node...

### DIFF
--- a/lib/initlocal.js
+++ b/lib/initlocal.js
@@ -168,7 +168,7 @@ function checkApplicationJS(applicationJSFile, cb) {
 function installFhDbLocally(cb) {
   exec('npm install fh-db', function(err, stdout, stderr) {
     log.silly("npm install fh-db stdout", stdout);
-    log.silly("npm install fh-db stdout", stderr);
+    log.silly("npm install fh-db stderr", stderr);
     if (err) return cb("Error installing fh-db locally - " + util.inspect(err) + " - " + stderr);
     return cb();
   });  

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name" : "fh-fhc",
   "description" : "A Command Line Interface for FeedHenry",
   "keywords" : [ "cli", "feedhenry" ],
-  "version": "0.7.24-BUILD-NUMBER",
+  "version": "0.7.25-BUILD-NUMBER",
   "preferGlobal" : true,
   "homepage" : "http://git.io/fh-fhc",
   "author" : "Damian Beresford <damian.beresford@feedhenry.com>",


### PR DESCRIPTION
...app (it was only added there for use with fhc local). fhc local now install fh-db during initlocal
