### PR TITLE
FHCLI-3 - re-add '-v' option

### DIFF
--- a/lib/cmd/common/-v.js
+++ b/lib/cmd/common/-v.js
@@ -1,0 +1,16 @@
+var fhc = require('../../fhc');
+
+module.exports = {
+  'desc': 'Version info about ththis tool',
+  'examples': [{
+    cmd: 'fhc -v',
+    desc: ''
+  }],
+  'demand': [],
+  'alias': {},
+  'describe': {},
+  customCmd: function(params, cb) {
+    var fhcVersionString = "FHC Version: " + fhc._version + '\n';
+    return cb(null, fhcVersionString);
+  }
+};


### PR DESCRIPTION
the -v option to display the version of the fh-fhc tool has been removed, it should be re-added.

The newer "version" command does not work directly after installation, since there is no target set