### PR TITLE
FHCLI-2 - when initial installed, "fhc version" command produces obscure error

### DIFF
--- a/lib/genericCommand.js
+++ b/lib/genericCommand.js
@@ -48,8 +48,13 @@ function _handleRequestGenerically(params, cb){
   headers['User-Agent'] = "FHC/" + fhc._version + ' ' + os.platform() + '/' + os.release();
   log.verbose(headers, "getHeaders");
 
+  var fhUrl = fhreq.getFeedHenryUrl();
+  if (fhUrl instanceof Error) {
+    return cb(fhUrl);
+  }
+
   var opts = {
-    url : urlUtils.resolve(fhreq.getFeedHenryUrl(), url),
+    url : urlUtils.resolve(fhUrl, url),
     headers : headers,
     method : method,
     proxy : fhc.config.get("proxy"),

--- a/lib/utils/request.js
+++ b/lib/utils/request.js
@@ -388,7 +388,7 @@ function getFeedHenryUrl () {
   var r = fhc.config.get("feedhenry");
   log.verbose(r, "feedhenry url");
   if (!r) {
-    return new Error("Must define feedhenry URL before accessing FeedHenry.");
+    return new Error("Must target a feedhenry domain first.");
   }
   if (r.substr(-1) !== "/") r += "/";
   fhc.config.set("feedhenry", r);


### PR DESCRIPTION
When using fh-fhc for the first time, there is not a current target.
executing the fhc version command produces an error
eg.
$ fhc version
fhc ERR! Error: getaddrinfo ENOTFOUND
fhc ERR!     at errnoException (dns.js:37:11)
fhc ERR!     at Object.onanswer [as oncomplete] (dns.js:124:16)
fhc ERR!
fhc ERR! System Darwin 14.0.0
fhc ERR! command "node" "/Users/mmurphy/node/current/bin/fhc" "version"
fhc not ok

The actual detail can vary, depending on client OS (helpdesk ticket refers to Windows)

A better message should be display, e.g. "need to target cloud platform first"

the apps command displays "$ fhc apps
fhc ERR! No user prefs! - 'You are not logged in. Login with fhc login <user> <passwd> or fhc keys user target <api-key>.'
fhc not ok"