### PR TITLE
RHMAP-2482 - Expose semver version of core in fhc version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Release 2.1.1 - 2015-11-26 - Wojciech Trocki
+------------------------------------------------------
+* RHMAP-2482 - Expose semver version of core in fhc version
+
 Release 2.1.0 - 2015-11-23 - Wei Li
 ------------------------------------------------------
 * RHMAP-2746 - Add support for configuring auto deploy

--- a/lib/cmd/common/version.js
+++ b/lib/cmd/common/version.js
@@ -3,13 +3,14 @@ var fhc = require('../../fhc'),
   _ = require('underscore'),
   request = require('request'),
   semver = require('semver');
+
 const dayInMs = 86400000;
 const daysToCache = 1;
 const timeout = 2000;
 const PATTERN = /-BUILD-NUMBER/;
 
-function cleanupVersion(version){
-  if(PATTERN.test(version)){
+function cleanupVersion(version) {
+  if (PATTERN.test(version)) {
     return version.replace(PATTERN, '');
   }
   return version;
@@ -18,38 +19,61 @@ function cleanupVersion(version){
 module.exports = {
   'desc': 'Version info about the FeedHenry instance we\'re connected to',
   'examples': [{
-    cmd: 'fhc version',
-    desc: ''
+    cmd: 'fhc version --format=json',
+    desc: 'Displays version in json format'
   }],
   'demand': [],
-  'alias': {},
+  'alias': {
+    'format': 'format',
+    0: 'format'
+  },
   'describe': {},
-  'url': 'box/srv/1.1/tst/version',
-  preCmd: function(params, cb) {
-    this.checkFHCUpToDate(function() {
+  'url': 'sys/info/version',
+  preCmd: function (params, cb) {
+    this.format = params.format;
+    this.checkFHCUpToDate(function () {
       return cb(null, params);
     });
   },
-  postCmd: function(params, cb) {
-    var msg = [],
-      fhcVersionString = "FHC Version: " + fhc._version;
+  postCmd: function (params, cb) {
+    if (this.format && this.format.toLowerCase() === 'json') {
+      return cb(null, this.getJsonMessage(params));
+    } else {
+      return cb(null, this.getTextMessage(params));
+    }
+  },
+  getJsonMessage: function (params) {
+    var jsonMsg = {};
+    jsonMsg.fhcVersion = fhc._version;
+    jsonMsg.productVersion = fhc.config.get('fhversion');
+    if (params.platform && params.platform.version) {
+      jsonMsg.platformVersion = params.platform.version;
+    }
+    return jsonMsg;
+  },
+  getTextMessage: function (params) {
+    var msg = [];
+    var fhcVersionString = "FHC Version: " + fhc._version;
     fhcVersionString = (this.latest.is) ? fhcVersionString + ' (Up to date)' : fhcVersionString;
-    msg.push("FeedHenry Product Version: " + fhc.config.get('fhversion'));
-    msg.push("FeedHenry " + params.Environment + " " + params.Release);
     msg.push(fhcVersionString);
+    msg.push("FeedHenry Product Version: " + fhc.config.get('fhversion'));
+    if (params.platform && params.platform.version) {
+      msg.push("FeedHenry Platform Version: " + params.platform.version);
+    }
     if (!this.latest.is) {
       msg.push(this.updateMessage());
     }
-    return cb(null, msg.join('\n'));
+    return msg.join('\n');
   },
-  checkFHCUpToDate: function(cb) {
+  checkFHCUpToDate: function (cb) {
     var self = this,
       cachedLatest = ini.get('fhclatest');
     try {
       cachedLatest = JSON.parse(cachedLatest)
-    } catch (error) {}
+    } catch (error) {
+    }
     if (!_.isEmpty(cachedLatest)) {
-      if(cachedLatest.current && semver.eq(cleanupVersion(cachedLatest.current), cleanupVersion(fhc._version))){
+      if (cachedLatest.current && semver.eq(cleanupVersion(cachedLatest.current), cleanupVersion(fhc._version))) {
         if (cachedLatest.ts - (new Date().getTime() - (dayInMs * daysToCache)) > 0) {
           self.latest = cachedLatest;
           return cb(cachedLatest.is);
@@ -59,14 +83,14 @@ module.exports = {
 
     return this.checkLatestFromServer(cb);
   },
-  checkLatestFromServer: function(cb) {
+  checkLatestFromServer: function (cb) {
     var self = this;
     request.get({
       proxy: ini.get('proxy'),
       json: true,
       url: 'http://registry.npmjs.org/fh-fhc/latest',
       timeout: timeout
-    }, function(err, response, body) {
+    }, function (err, response, body) {
       if (err || !body || !body.version) {
         self.errorChecking = true;
         return cb(false);
@@ -84,12 +108,12 @@ module.exports = {
 
       // Cache the result
       ini.set('fhclatest', JSON.stringify(self.latest), 'user');
-      ini.save(function() {
+      ini.save(function () {
         return cb(isUpToDate);
       });
     });
   },
-  updateMessage: function() {
+  updateMessage: function () {
     if (this.errorChecking) {
       return 'Error checking latest version';
     }
@@ -97,20 +121,20 @@ module.exports = {
       'npm install -g fh-fhc';
   },
   //Checking If The Platform Version Can Be Used With This Version Of fhc
-  checkTargetVersion: function(targ, cb) {
-    request(targ + "/" + this.url, function(err, response, body){
-      if(err) return cb(err);
+  checkTargetVersion: function (targ, cb) {
+    request(targ + "/" + this.url, function (err, response, body) {
+      if (err) return cb(err);
       var platformDetails;
 
-      try{
+      try {
         platformDetails = JSON.parse(body);
-      } catch(e){
+      } catch (e) {
         return cb(new Error("Invalid Platform Data"));
       }
 
       //If the platform is less that a certain version, then it can't be used with this version of fhc.
-      if(semver.lt(platformDetails.Release, fhc._minPlatformVersion)){
-        return cb(new Error("The Platform You Are Targeting Is Not Compatible With This Version (" + fhc._version + ") Of fhc. Please Install A Previous Version: npm install fh-fhc@^" + (semver.major(fhc._version) - 1) + ".0.0" ));
+      if (semver.lt(platformDetails.Release, fhc._minPlatformVersion)) {
+        return cb(new Error("The Platform You Are Targeting Is Not Compatible With This Version (" + fhc._version + ") Of fhc. Please Install A Previous Version: npm install fh-fhc@^" + (semver.major(fhc._version) - 1) + ".0.0"));
       }
 
       return cb();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.1.0-BUILD-NUMBER",
+  "version": "2.1.1-BUILD-NUMBER",
   "_minPlatformVersion": "7.15.0-1661",
   "keywords": [
     "feedhenry"


### PR DESCRIPTION
Updated endpoint used to obtain platform version. Instead of using java milicore version we use now semver platform format exposed by gui node server. Added support for JSON format - needed to automate some specific tasks depending on platform version. When requesting JSON format we do not check for new tool upgrade (this will be used internally and we do not need that to be included in json)