### PR TITLE
add wait flag for app creation

### DIFF
--- a/lib/cmd/fh3/app/create.js
+++ b/lib/cmd/fh3/app/create.js
@@ -1,4 +1,8 @@
 var templates = require('../../common/templates.js');
+var async = require('async');
+var common = require('../../../common');
+
+var args;
 module.exports = {
   'desc': 'Creates an application.',
   'examples': [
@@ -16,7 +20,8 @@ module.exports = {
     0: 'project',
     'project': 'p',
     'title': 't',
-    'env': 'e'
+    'env': 'e',
+    'wait': 'w'
   },
   'describe': {
     'project': 'Unique 24 character GUID of the project you want this app to be created in',
@@ -24,7 +29,8 @@ module.exports = {
     'template': 'Template of your app - e.g. hello_world_mbaas_instance. See fhc templates apps',
     'repo': 'Repository to clone your app from',
     'branch': 'Git branch to clone from',
-    'env': 'If specified and the app is deployable, the app will be deployed to this environment automatically. Set it to "none" will not deploy the app'
+    'env': 'If specified and the app is deployable, the app will be deployed to this environment automatically. Set it to "none" will not deploy the app',
+    'wait': 'Optional. If this is set to true, the command will wait until the app is deployed (if enabled)'
   },
   'defaults': {
     'template': 'hello_world_mbaas_instance'
@@ -34,6 +40,7 @@ module.exports = {
   },
   'method': 'post',
   'preCmd': function (argv, cb) {
+    args = argv;
     var params = {
       title: argv.title,
       project: argv.project,
@@ -70,6 +77,19 @@ module.exports = {
         setAutoDeploy(params);
         return cb(null, params);
       });
+    }
+  },
+  'postCmd': function(params, cb){
+    if(args && (args.wait === true || args.wait === 'true')){
+      async.map([params.scmCacheKey], common.waitFor, function(err, logs){
+        if(err){
+          return cb(err);
+        }
+        params.logs = logs[0];
+        return cb(null, params);
+      });
+    } else {
+      process.nextTick(cb);
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.3.1-BUILD-NUMBER",
+  "version": "2.3.2-BUILD-NUMBER",
   "_minPlatformVersion": "3.5.0",
   "keywords": [
     "feedhenry"


### PR DESCRIPTION
During the load test, I discovered that the app creation command doesn't wait for app to be available (cloned by fh-scm). This means if the app is being deployed right after the creating, the deploy request will fail.

In order to allow my performance test, I added a wait flag to the app creating command.