### PR TITLE
Allow the tailing of stderr again

### DIFF
--- a/lib/cmd/fh3/app/logs/tail.js
+++ b/lib/cmd/fh3/app/logs/tail.js
@@ -4,7 +4,7 @@ var _ = require('underscore');
 module.exports = {
   'desc': 'Display the end part of application log file and monitor how it changes over the time.',
   'examples': [{
-    cmd: 'fhc app logs tail --app=2bf4gg3gfefsdgfdsg4fdgs34 --env=dev --last 100 --logname std.out.log',
+    cmd: 'fhc app logs tail --app=2bf4gg3gfefsdgfdsg4fdgs34 --env=dev --last 100 --logname=std.out.log',
     desc: 'Monitors and displays the last "100" lines of "std.out.log"'
   }],
   'demand': ['app', 'env'],
@@ -39,7 +39,7 @@ module.exports = {
     };
     if (params.last) payload.last = params.last;
     if (params.offset) payload.offset = params.offset;
-    if (params.logname) payload.logname = params.logName;
+    if (params.logname) payload.logname = params.logname;
 
     return cb(null, payload);
   },


### PR DESCRIPTION
Fixing bug where passing logname was not being picked up. This allows tailing of stderr again. 

Out of interest the tail functionality used to return a combination of stdout and stderr? Is this functionality that could be easily added back in? 
Can someone point me in the right direction of which component deals with api/v2/mbaas/...../...../apps/...../logs/chunk