### PR TITLE
add the extra size parameter when creating mbaases

### DIFF
--- a/lib/cmd/fh3/admin/mbaas/create.js
+++ b/lib/cmd/fh3/admin/mbaas/create.js
@@ -1,6 +1,6 @@
 module.exports = { 
   'desc' : 'Creates an mBaaS.',
-  'examples' : [{ cmd : 'fhc admin mbaas create --id=<mBaaS id> --url=<mBaaS URL> --servicekey=<mBaaS Service Key> --username=<mBaaS User Name> --password=<mBaaS Password> --decoupled=<bool>', desc : 'Creates an mbaas'}],
+  'examples' : [{ cmd : 'fhc admin mbaas create --id=<mBaaS id> --url=<mBaaS URL> --servicekey=<mBaaS Service Key> --username=<mBaaS User Name> --password=<mBaaS Password> --decoupled=<bool> --size=<mBaas Size>', desc : 'Creates an mbaas'}],
   'demand' : ['id', 'url', 'servicekey', 'username', 'password'],
   'alias' : {},
   'describe' : {
@@ -9,7 +9,8 @@ module.exports = {
     'servicekey' : 'Service key to authenticate the mBaaS',
     'username' : 'mBaaS Username',
     'password' : 'mBaaS Password',
-    'decoupled':'flag them mbaas as decoupled'
+    'decoupled':'flag them mbaas as decoupled',
+    'size': 'The size of the mBaas'
   },
   'url' : '/api/v2/mbaases',
   'method' : 'post',

--- a/lib/cmd/fh3/admin/mbaas/update.js
+++ b/lib/cmd/fh3/admin/mbaas/update.js
@@ -1,6 +1,6 @@
 module.exports = { 
   'desc' : 'Update an mBaaS.',
-  'examples' : [{ cmd : 'fhc admin mbaas update --id=<mBaaS id> --url=<mBaaS URL> --servicekey=<mBaaS Service Key> --username=<mBaaS User Name> --password=<mBaaS Password> --decoupled=<bool>', desc : 'Updates an mbaas with id <mbaasId>'}],
+  'examples' : [{ cmd : 'fhc admin mbaas update --id=<mBaaS id> --url=<mBaaS URL> --servicekey=<mBaaS Service Key> --username=<mBaaS User Name> --password=<mBaaS Password> --decoupled=<bool> --size=<mBaas Size>', desc : 'Updates an mbaas with id <mbaasId>'}],
   'demand' : ['id'],
   'alias' : {},
   'describe' : {
@@ -9,7 +9,8 @@ module.exports = {
     'servicekey' : 'Service key to authenticate the mBaaS',
     'username' : 'mBaaS Username',
     'password' : 'mBaaS Password',
-    'decoupled':'flag them mbaas as decoupled'
+    'decoupled':'flag them mbaas as decoupled',
+    'size': 'The size of the mBaas'
   },
   'url' : function(params){
     return '/api/v2/mbaases/' + params.id;

--- a/lib/common.js
+++ b/lib/common.js
@@ -271,12 +271,12 @@ exports.createTableForTeams = function (teams) {
 
 exports.createTableForMbaasTargets = function (mbaas_targets) {
   var table = new Table({
-    head: ['ID', 'URL', 'Service Key', 'Username', 'Password', 'Modified'],
+    head: ['ID', 'URL', 'Service Key', 'Username', 'Password', 'Modified', 'Size'],
     style: exports.style()
   });
 
   _.each(mbaas_targets, function (mbaas) {
-    table.push([mbaas._id, mbaas.url, mbaas.servicekey, mbaas.username, mbaas.password, moment(mbaas.modified).fromNow()]);
+    table.push([mbaas._id, mbaas.url, mbaas.servicekey, mbaas.username, mbaas.password, moment(mbaas.modified).fromNow(), mbaas.size]);
   }, this);
 
   return table;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.3.3-BUILD-NUMBER",
+  "version": "2.3.4-BUILD-NUMBER",
   "_minPlatformVersion": "3.5.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.2.1
+sonar.projectVersion=2.3.4
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
## Motivation

To allow provide the "size" information when creating the mbaas targets via fhc. This is mainly to help ops to easily figure out what the sizes of the mbaases.

## Modifications

When create/update mbaases, an extra size field can be provided. When list mbaases, the size info is listed too.

## JIRA

https://issues.jboss.org/browse/RHMAP-4878
