### PR TITLE
[RHMAP-4932] fhc admin environment create allows null/undefined - fix on fh-fhc

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,9 @@ module.exports = function(grunt) {
     _unit_args: '--setUp ./test/setupTeardown.js --tearDown ./test/setupTeardown.js test/unit',
     _accept_args: 'test/accept/*',
     unit: ['env NODE_PATH=.:./lib <%= _test_runner %> <%= _unit_args %>/fh3/**/*',
-      'env NODE_PATH=.:./lib <%= _test_runner %> <%= _unit_args %>/legacy/*'],
+      'env NODE_PATH=.:./lib <%= _test_runner %> <%= _unit_args %>/common/*',
+      'env NODE_PATH=.:./lib <%= _test_runner %> <%= _unit_args %>/legacy/*'
+      ],
     accept: 'env NODE_PATH=.:./lib <%= _test_runner %> <%= _accept_args %>',
     unit_cover: 'istanbul cover --dir cov-unit <%= _test_runner %> -- <%= _unit_args %>',
     accept_cover: 'istanbul cover --dir cov-unit <%= _test_runner %> -- <%= _accept_args %>',

--- a/lib/cmd/fh3/admin/environments/create.js
+++ b/lib/cmd/fh3/admin/environments/create.js
@@ -12,12 +12,19 @@ module.exports = {
   'method' : 'post',
   'preCmd' : function(params, cb){
     var targets = params.targets.split(',');
+    if(typeof params.autoDeployOnCreate === 'undefined') {
+      params.autoDeployOnCreate = false;
+    }
+    if(typeof params.autoDeployOnUpdate === 'undefined') {
+      params.autoDeployOnUpdate = false;
+    }
+
     return cb(null, {
       _id : params.id, 
       label : params.label, 
       targets : targets, 
-      autoDeployOnCreate : params.autoDeployOnCreate || false,
-      autoDeployOnUpdate : params.autoDeployOnUpdate || false
+      autoDeployOnCreate : params.autoDeployOnCreate,
+      autoDeployOnUpdate : params.autoDeployOnUpdate
     });
   }
 };

--- a/lib/cmd/fh3/admin/environments/create.js
+++ b/lib/cmd/fh3/admin/environments/create.js
@@ -1,10 +1,10 @@
 module.exports = { 
-  'desc' : 'Creates an environments.',
+  'desc' : 'Creates an environment.',
   'examples' : [{ cmd : 'fhc admin environments create --id=<environment id> --label=<label> --targets=<mbaasTargetId1>,<mbaasTargetId2>', desc : 'Creates an environment'}],
   'demand' : ['id', 'label', 'targets'],
   'alias' : {},
   'describe' : {
-    'id' : 'Some unique identifier for your environment',
+    'id' : 'Unique identifier for your environment',
     'label' : 'A label describing your environment',
     'targets' : 'Comma separated list of mBaaS Target hostnames'
   },
@@ -20,5 +20,4 @@ module.exports = {
       autoDeployOnUpdate : params.autoDeployOnUpdate || false
     });
   }
-  
 };

--- a/lib/cmd/fh3/admin/environments/create.js
+++ b/lib/cmd/fh3/admin/environments/create.js
@@ -16,8 +16,8 @@ module.exports = {
       _id : params.id, 
       label : params.label, 
       targets : targets, 
-      autoDeployOnCreate : params.autoDeployOnCreate,
-      autoDeployOnUpdate : params.autoDeployOnUpdate
+      autoDeployOnCreate : params.autoDeployOnCreate || false,
+      autoDeployOnUpdate : params.autoDeployOnUpdate || false
     });
   }
   

--- a/lib/common.js
+++ b/lib/common.js
@@ -294,7 +294,11 @@ exports.createTableForEnvironments = function (environments) {
       targets.push(target._id);
     });
 
-    table.push([env._id, env.label, env.autoDeployOnCreate, env.autoDeployOnUpdate, targets.join(", "), moment(env.modified).fromNow()]);
+    // Display undefined options as 'false'
+    var autoDeployOnCreate = env.autoDeployOnCreate || false;
+    var autoDeployOnUpdate = env.autoDeployOnUpdate || false;
+
+    table.push([env._id, env.label, autoDeployOnCreate, autoDeployOnUpdate, targets.join(", "), moment(env.modified).fromNow()]);
   }, this);
 
   return table;

--- a/lib/common.js
+++ b/lib/common.js
@@ -295,8 +295,14 @@ exports.createTableForEnvironments = function (environments) {
     });
 
     // Display undefined options as 'false'
-    var autoDeployOnCreate = env.autoDeployOnCreate || false;
-    var autoDeployOnUpdate = env.autoDeployOnUpdate || false;
+    var autoDeployOnCreate = env.autoDeployOnCreate;
+    if(typeof autoDeployOnCreate === 'undefined') {
+      autoDeployOnCreate = false;
+    }
+    var autoDeployOnUpdate = env.autoDeployOnUpdate;
+    if(typeof autoDeployOnUpdate === 'undefined') {
+      autoDeployOnUpdate = false;
+    }
 
     table.push([env._id, env.label, autoDeployOnCreate, autoDeployOnUpdate, targets.join(", "), moment(env.modified).fromNow()]);
   }, this);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.3.5-BUILD-NUMBER",
+  "version": "2.3.6-BUILD-NUMBER",
   "_minPlatformVersion": "3.5.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.3.5
+sonar.projectVersion=2.3.6
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/fixtures/admin/environments.json
+++ b/test/fixtures/admin/environments.json
@@ -1,0 +1,16 @@
+[
+    {
+      "status" : "ok",
+      "_id" : "1a",
+      "label" : "My env",
+      "targets" : ["http://www.1.com", "http://www.2.com"]
+    },
+    {
+      "status" : "ok",
+      "_id" : "2a",
+      "label" : "Another env",
+      "autoDeployOnCreate" : true,
+      "autoDeployOnUpdate" : true,
+      "targets" : ["http://www.1.com", "http://www.2.com"]
+    }
+]

--- a/test/fixtures/admin/fixture_environments.js
+++ b/test/fixtures/admin/fixture_environments.js
@@ -1,30 +1,23 @@
 var nock = require('nock');
+var data = require('./environments');
 
-var envReplies = {
-  crud : function(){
-    return { 
-      status : 'ok',
-      _id : '1a',
-      label : 'My env',
-      targets : ['http://www.1.com', 'http://www.2.com']
-    };
-  },
-  list : function(){
-    return [envReplies.crud()];
-  }
-};
+function echoWithOk(uri, body) {
+  var parsed = JSON.parse(body);
+  parsed.status = 'ok';
+  return parsed;
+}
 
 module.exports = nock('https://apps.feedhenry.com')
 .filteringRequestBody(function() {
   return '*';
 })
 .post('/api/v2/environments', '*')
-.reply(200, envReplies.crud)
+.reply(200, echoWithOk)
 .get('/api/v2/environments/1a', '*')
-.reply(200, envReplies.crud)
+.reply(200, data[0])
 .put('/api/v2/environments/1a', '*')
-.reply(200, envReplies.crud)
+.reply(200, echoWithOk)
 .delete('/api/v2/environments/1a', '*')
-.reply(200, envReplies.crud)
+.reply(200, data[0])
 .get('/api/v2/environments/all', '*')
-.reply(200, envReplies.list);
+.reply(200, data);

--- a/test/unit/common/test_createTable.js
+++ b/test/unit/common/test_createTable.js
@@ -1,0 +1,19 @@
+var assert = require('assert');
+var common = require('common');
+var environments = require('test/fixtures/admin/environments');
+
+module.exports = {
+  'test createTableForEnvironments': function (done) {
+    var table = common.createTableForEnvironments(environments);
+    assert.equal(environments.length, table.length);
+
+    // autoDeployOnCreate
+    assert.equal(table['0'][2], false);
+    assert.equal(table['1'][2], true);
+
+    // autoDeployOnUpdate
+    assert.equal(table['0'][3], false);
+    assert.equal(table['1'][3], true);
+    return done();
+  }
+};

--- a/test/unit/fh3/admin/test_environments.js
+++ b/test/unit/fh3/admin/test_environments.js
@@ -14,8 +14,16 @@ module.exports = {
     'test admin-environments list': function(cb) {
       adminenvironments.list({}, function (err, data){
         assert.equal(err, null);
-        assert.equal(data.length, 1);
+        assert.equal(data.length, 2);
         assert.equal(data[0].label, 'My env');
+        assert.equal(data[1].label, 'Another env');
+
+        var table = data._table;
+        assert.equal(table['0'][2], false);
+        assert.equal(table['0'][3], false);
+
+        assert.equal(table['1'][2], true);
+        assert.equal(table['1'][3], true);
         return cb();
       });
     },
@@ -27,14 +35,17 @@ module.exports = {
       });
     },
     'test admin-environments create': function(cb) {
-      adminenvironments.create({ label : 'foo', targets : '1,2,3', id : '1a' }, function (err, data){
+      adminenvironments.create({ label : 'My env', targets : '1,2,3', id : '1a' }, function (err, data){
         assert.equal(err, null);
+
+        assert.deepEqual(data.targets, ['1', '2', '3']);
         assert.equal(data.label, 'My env');
+        assert.equal(data._id, '1a');
         return cb();
       });
     },
     'test admin-environments update': function(cb) {
-      adminenvironments.update({ label : 'foo', targets : '1,2,3', id : '1a' }, function (err){
+      adminenvironments.update({ label : 'My env', targets : '1,2,3', id : '1a' }, function (err){
         assert.equal(err, null);
         return cb();
       });

--- a/test/unit/fh3/admin/test_environments_commands.js
+++ b/test/unit/fh3/admin/test_environments_commands.js
@@ -1,0 +1,21 @@
+var assert = require('assert');
+var create = require('cmd/fh3/admin/environments/create.js');
+var environments = require('test/fixtures/admin/environments');
+module.exports = {
+  'test admin environments create command': function (cb) {
+    // map fixture's fields to the ones that are going to come from the command line
+    environments = environments.map(function (env) {
+      env.id = env._id;
+      // command expects `targets` to be a csv string
+      env.targets = env.targets.join(',');
+      return env;
+    });
+
+    environments.forEach(function (env) {
+      create.preCmd(env, function (_, entity) {
+        assert.equal(entity._id, env._id);
+      });
+    });
+    return cb();
+  }
+}


### PR DESCRIPTION
This is a quite simple fix on the cli front-end. From @wei-lee's input I think accepting `undefined` on supercore is probably benign, but if time allows I'd like to guard it against that too, to get to know the module and the cluster deploy+testing procedure.

Added a couple tests at the unit level, that don't depend on mocking web calls. Hopefully to break out the table-creating functions from the huge `common.js` file.