### PR TITLE
RHMAP-3295 - noAppend flag for saving new enviroments.

### DIFF
--- a/lib/cmd/fh3/admin/environments/create.js
+++ b/lib/cmd/fh3/admin/environments/create.js
@@ -1,12 +1,18 @@
-module.exports = { 
+var log = require("../../../../utils/log");
+
+module.exports = {
   'desc' : 'Creates an environment.',
-  'examples' : [{ cmd : 'fhc admin environments create --id=<environment id> --label=<label> --targets=<mbaasTargetId1>,<mbaasTargetId2>', desc : 'Creates an environment'}],
+  'examples' : [{ cmd : 'fhc admin environments create --id=<environment id> --label=<label> --targets=<mbaasTargetId1>,<mbaasTargetId2>',
+    desc : 'Creates an environment'}],
   'demand' : ['id', 'label', 'targets'],
   'alias' : {},
   'describe' : {
     'id' : 'Unique identifier for your environment',
     'label' : 'A label describing your environment',
-    'targets' : 'Comma separated list of mBaaS Target hostnames'
+    'targets' : 'Comma separated list of mBaaS Target hostnames',
+    'autoDeployOnCreate' : 'option used to setup automatic deployment to this environment when creating new project/app.',
+    'autoDeployOnUpdate' : 'option used to setup automatic deployment to this environment when making source code changes within app.',
+    'noAppend' : 'option used to create environment without adding it to the list of environments available for the domain.'
   },
   'url' : '/api/v2/environments',
   'method' : 'post',
@@ -15,16 +21,24 @@ module.exports = {
     if(typeof params.autoDeployOnCreate === 'undefined') {
       params.autoDeployOnCreate = false;
     }
-    if(typeof params.autoDeployOnUpdate === 'undefined') {
+    if(typeof params.autoDeployOnUpdate === 'undefined'){
       params.autoDeployOnUpdate = false;
     }
+    if(typeof params.noAppend === 'undefined'){
+      params.noAppend = false;
+    }
+    var request = {
+      _id: params.id,
+      label: params.label,
+      targets: targets,
+      autoDeployOnCreate: params.autoDeployOnCreate,
+      autoDeployOnUpdate: params.autoDeployOnUpdate,
+      noAppend: params.noAppend
+    };
 
-    return cb(null, {
-      _id : params.id, 
-      label : params.label, 
-      targets : targets, 
-      autoDeployOnCreate : params.autoDeployOnCreate,
-      autoDeployOnUpdate : params.autoDeployOnUpdate
-    });
-  }
+    if(params.noAppend){
+      log.warn("Warning! noAppend flag used. Environment will not appear in environment list. ");
+    }
+    return cb(null, request);
+ }
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.3.6-BUILD-NUMBER",
+  "version": "2.3.7-BUILD-NUMBER",
   "_minPlatformVersion": "3.5.0",
   "keywords": [
     "feedhenry"


### PR DESCRIPTION
## Motivation

Add new `noAppend` flag to support saving environment without adding it to the list of available environments. This command may be used when setting up new cluster and we want to properly
adjust permission levels for environments. 

## Command

`fhc admin environments create --id=test --label=test --targets=mbaas1 --noAppend`

## Review

ping @wei-lee @pb82 