### PR TITLE
Added support for tailing error logs 

### DIFF
--- a/lib/cmd/fh3/app/logs/tail.js
+++ b/lib/cmd/fh3/app/logs/tail.js
@@ -1,8 +1,10 @@
 var fhc = require("../../../../fhc");
 var _ = require('underscore');
+var log = require("../../../../utils/log");
 
 module.exports = {
-  'desc': 'Display the end part of application log file and monitor how it changes over the time.',
+  'desc': 'Display the end part of application log files and monitor how it changes over the time. ' +
+  'By default command will display most recent stdout and stderr logs.',
   'examples': [{
     cmd: 'fhc app logs tail --app=2bf4gg3gfefsdgfdsg4fdgs34 --env=dev --last=100 --logname=std.out.log',
     desc: 'Monitors and displays the last "100" lines of "std.out.log"'
@@ -32,20 +34,64 @@ module.exports = {
     return "api/v2/mbaas/" + fhc.curTarget + "/" + argv.deploytarget + "/apps/" + fhc.appId(argv.guid) + "/logs/chunk";
   },
   'preCmd': function (params, cb) {
-    var payload = {
+    var stdRequest = {
       "guid": params.app,
       "action": "logchunk",
       "deploytarget": params.env
     };
-    if (params.last) payload.last = params.last;
-    if (params.offset) payload.offset = params.offset;
-    if (params.logname) payload.logname = params.logname;
 
-    return cb(null, payload);
+    if (params.last) {
+      stdRequest.last = params.last;
+    }
+    if (params.offset) {
+      stdRequest.offset = params.offset;
+    }
+    if (params.logname) {
+      stdRequest.logname = params.logname;
+      return cb(null, stdRequest, null);
+    }else{
+      this.tailStdAndErrorLog(stdRequest,params, cb);
+    }
   },
-  'customCmd': function (params, cb) {
+  'tailStdAndErrorLog':function(stdRequest,params, cb){
     var self = this;
-    this.executeStandardRequest(params, function (err, result) {
+    var listParams = {
+      "app": params.app,
+      "env": params.env
+    };
+    fhc.app.logs.list(listParams, function(err, res){
+      if(res && res.logs && res.logs.length > 1){
+        var stdLog = self.getFirst(res.logs, "stdout.log.");
+        var errorLog = self.getFirst(res.logs, "stderr.log.");
+        var errorRequest = _.clone(stdRequest);
+        stdRequest.logname = stdLog.name;
+        errorRequest.logname = errorLog.name;
+        log.warn("No log file specified. Fetching logs from latest log files. \nStandard output: " +
+          stdLog.name + "\nError log: " + errorLog.name);
+        return cb(null, stdRequest, errorRequest);
+      }else{
+        log.warn("Cannot get latest log files. Fetching standard output log.");
+        return cb(null, stdRequest, null);
+      }
+    });
+  },
+  'getFirst': function(list,name){
+    return _.find(list, function(element){
+      if(element.name.indexOf(name)===0){
+        return true;
+      }
+    });
+  },
+  'customCmd': function(request, secondRequest, cb){
+    this.execute(request, cb);
+    // Tail second file (error log)
+    if(secondRequest){
+      this.execute(secondRequest, cb);
+    }
+  },
+  'execute':function(params,cb){
+    var self = this;
+    self.executeStandardRequest(params, function (err, result) {
       if (err) {
         cb(err, result);
       } else if (result && result.msg) {
@@ -55,11 +101,12 @@ module.exports = {
         }
         if (msg.data && msg.data.length !== 0) {
           var logString = msg.data.join("\n");
-          console.log(logString);
+          console.log(params.logname + ":");
+          console.log(logString+"\n");
         }
       }
-      setTimeout(_.bind(self.customCmd, self, params, cb), 3000);
+      setTimeout(_.bind(self.execute, self, params, cb), 4000);
       // No callback (inifinite loop)
     });
-  },
+  }
 };

--- a/lib/genericCommand.js
+++ b/lib/genericCommand.js
@@ -102,8 +102,8 @@ module.exports = function (cmd) {
       // Allow to reuse standard request function in custom command.
       cmd.executeStandardRequest = _.bind(_handleRequestGenerically, cmd);
       // Apply a useful scope
-      var custom = function (params, cb) {
-        customCmd.apply(cmd, [params, cb]);
+      var custom = function () {
+        customCmd.apply(cmd, arguments);
       };
       series.push(custom);
     } else {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.3.7-BUILD-NUMBER",
+  "version": "2.3.8-BUILD-NUMBER",
   "_minPlatformVersion": "3.5.0",
   "keywords": [
     "feedhenry"


### PR DESCRIPTION
# Motivation
Allow to tail both error and stdout in one command. 
Solution is using list to fetch all logs and then selecting two most recent ones. 
This is workaround for current api limitations. 

Code inspired on another PR added by community member. 

# Side effects

Tailing 2 different files so logs can appear in different order 

ping @alanmoran, @pb82, @paolobueno, @ziccardi 