### PR TITLE
RHMAP-4395 call deleteapp supercore endpoint directly

### DIFF
--- a/lib/cmd/common/undeploy.js
+++ b/lib/cmd/common/undeploy.js
@@ -1,8 +1,8 @@
 module.exports = undeploy;
 
 undeploy.desc = "Undeploy a cloud app";
-undeploy.usage = "fhc undeploy <app-id> [apptype] --env=<environment> (where 'apptype' is 'cloud' (default) or 'embed')" +
-  "\ne.g. fhc undeploy 12345 cloud --env=dev";
+undeploy.usage = "fhc undeploy --id=<app-id> --env=<environment> --domain=<domain> (optional: --embed)" +
+  "\ne.g. fhc undeploy --id=j7hslnrb257zkr4qzjndoqkl --env=dev --domain=testing";
 
 var log = require("../../utils/log");
 var fhc = require("../../fhc");
@@ -10,34 +10,35 @@ var fhreq = require("../../utils/request");
 var common = require("../../common");
 var ini = require('../../utils/ini');
 
-// Main undeploy entry point
+var DELETEAPP_ENDPOINT = "api/v2/mbaas/deleteapp";
+
+/**
+ * Main undeploy entry point
+ * required args are id, env and domain
+ * `embed` can be specified and will be sent in the request to supercore
+ */
 function undeploy(argv, cb) {
-  var args = argv._;
-  if (args.length === 0) {
+  if (!argv.id || !argv.env || !argv.domain) {
     return cb(undeploy.usage);
   }
 
-  var appId = fhc.appId(args[0]);
-  var appType = args[1];
   var deployTarget = ini.getEnvironment(argv);
-
-  return undeployApp(appId, deployTarget, appType, cb);
+  return undeployApp(argv.id, deployTarget, argv.domain, argv.embed, cb);
 }
 
-function undeployApp(appId, deployTarget, appType, cb) {
-  var type = appType || "cloud";
-  var params = {
-    guid: appId,
-    apptype: type,
-    deploytarget: deployTarget
+function undeployApp(appId, deployTarget, domain, embed, cb) {
+  var body = {
+    embed: embed || false
   };
 
-  common.doApiCall(fhreq.getFeedHenryUrl(), "box/srv/1.1/environments/" + deployTarget + "/apps/" + appId + "/undeploy", params, "Error undeploying app: ", function (err, data) {
-    if (err) return cb(err);
-    log.info("App Undeployed");
-    log.silly(data, "undeploy app");
-    return cb(err, data);
-  });
+  common.doApiCall(fhreq.getFeedHenryUrl(),
+    [DELETEAPP_ENDPOINT, domain, deployTarget, appId].join("/"), body, "Error undeploying app: ",
+    function (err, data) {
+      if (err) return cb(err);
+      log.info("App Undeployed");
+      log.silly(data, "undeploy app");
+      return cb(err, data);
+    });
 }
 
 // bash completion

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.3.8",
+  "version": "2.3.9",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.3.8-BUILD-NUMBER",
+  "version": "2.3.9-BUILD-NUMBER",
   "_minPlatformVersion": "3.5.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.3.6
+sonar.projectVersion=2.3.9
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
fixes RHMAP-4395

The `undeploy` command in fhc used to call into millicore which then would call into the supercore route (`api/v2/mbaas/deleteapp`) to undeploy an app.

There were some problems on the millicore side (like hardcoded environments dev and live). I decided that it is not really necessary to call into millicore at all.

With this PR i'm directly calling the proper supercore route. It requires an additional `domain` attribute. I also removed the `--type` attribute and replaced it with `--embed` since it was only used to determine wether to set embed to true or false (in Millicore).

This PR changes the required parameters of the `fhc undeploy` command so i'm not sure if this is ok.

ping @wei-lee @wtrocki 