### PR TITLE
Using service read object to display table

### DIFF
--- a/lib/cmd/fh3/services.js
+++ b/lib/cmd/fh3/services.js
@@ -63,7 +63,7 @@ function listServiceDataSources(serviceId, cb){
 
     common.doGetApiCall(fhreq.getFeedHenryUrl(), "api/v2/services/" + service.apps[0].guid + "/data_sources", "Error reading Service data sources. ", function(err, dataSources){
       if (ini.get('table') === true) {
-        services.table = common.createTableForDataSources(dataSources || []);
+        services.table = common.createTableForDataSources(dataSources || [], service);
       }
 
       cb(err, dataSources);

--- a/lib/common.js
+++ b/lib/common.js
@@ -254,16 +254,17 @@ exports.createTableForApps = function (apps) {
  * A Table For Listing Data Sources
  * @param dataSources
  */
-exports.createTableForDataSources = function(dataSources){
+exports.createTableForDataSources = function(dataSources, service){
   var table = new Table({
-    head: ['ID', 'Name', 'Service ID', 'Service Name', 'Endpoint', 'Refresh Interval', 'Number Of Audit Logs'],
+    head: ['ID', 'Name', 'Service ID', 'Service Title', 'Endpoint', 'Refresh Interval', 'Number Of Audit Logs'],
     style: exports.style()
   });
 
   dataSources = _.isArray(dataSources) ? dataSources : [dataSources];
 
   _.each(dataSources, function (dataSource) {
-    table.push([dataSource._id, dataSource.name, dataSource.service.guid, dataSource.service.title, dataSource.endpoint, moment.duration(dataSource.refreshInterval, 'minutes').humanize(), dataSource.numAuditLogEntries]);
+    var title = service && service.title ? service.title : dataSource.service.title;
+    table.push([dataSource._id, dataSource.name, dataSource.serviceGuid, title, dataSource.endpoint, moment.duration(dataSource.refreshInterval, 'minutes').humanize(), dataSource.numAuditLogEntries]);
   }, this);
 
   return table;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.5.0",
+  "version": "2.4.0",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/test/fixtures/fixture_service.js
+++ b/test/fixtures/fixture_service.js
@@ -1,0 +1,156 @@
+module.exports = {
+  get: function () {
+    return {
+      "type": "CONNECTOR",
+      "template": null,
+      "guid": "someserviceguid",
+      "title": "Mock Service",
+      "sysOwner": "yibx7zf6egqqkge3skqttjhv",
+      "sysModified": 1458044450173,
+      "sysVersion": 30,
+      "featured": false,
+      "sysCreated": 1458040959170,
+      "apps": [{
+        "scmCacheKey": null,
+        "hierarchy": null,
+        "type": "cloud_nodejs",
+        "description": "",
+        "domain": "testing",
+        "runtime": {
+          "test": "node010",
+          "dev": "node010",
+          "multinode": "node010",
+          "live": "node010"
+        },
+        "template": null,
+        "email": "testing-admin@example.com",
+        "guid": "someserviceid",
+        "title": "testds",
+        "sysOwner": "yibx7zf6egqqkge3skqttjhv",
+        "sysModified": 1458044450180,
+        "legacy": false,
+        "gitRefs": {},
+        "sysVersion": 28,
+        "sourcePath": "",
+        "embed": false,
+        "gitApp": true,
+        "deployedGitRefs": {
+          "test": {
+            "type": "branch",
+            "value": "master",
+            "hash": "05b987f5045bf4868e3872ed2abe4ce3a48fab14"
+          },
+          "dev": {
+            "type": "branch",
+            "value": "master",
+            "hash": "05b987f5045bf4868e3872ed2abe4ce3a48fab14"
+          },
+          "multinode": {
+            "type": "branch",
+            "value": "master",
+            "hash": "05b987f5045bf4868e3872ed2abe4ce3a48fab14"
+          },
+          "live": {
+            "type": "branch",
+            "value": "master",
+            "hash": "05b987f5045bf4868e3872ed2abe4ce3a48fab14"
+          }
+        },
+        "sysCreated": 1458040959184,
+        "scmUrl": "git@ndonnellycore-single-node1.feedhenry.local:testing/testds-testds.git",
+        "scmKey": null,
+        "scmBranch": "master",
+        "internallyHostedRepo": true,
+        "client": false,
+        "newApp": false,
+        "targetable": true,
+        "apiKey": "d42d04e00cbb09a0e35a34ce9cd219d3fa928066",
+        "windowsPhonePushInformation": null,
+        "androidPushInformation": null,
+        "iOSPushInformation": null,
+        "sysGroupFlags": 70111,
+        "sysGroupList": "",
+        "deployable": true,
+        "envsToDeployOnCreate": [{
+          "propType": "autodeploy.update",
+          "environment": "*",
+          "deployEnabled": false,
+          "propKey": "autodeploy.update.*",
+          "propValue": {
+            "environment": "*",
+            "deployEnabled": false
+          }
+        }],
+        "envsToDeployOnUpdate": [{
+          "propType": "autodeploy.update",
+          "environment": "test",
+          "deployEnabled": false,
+          "propKey": "autodeploy.update.test",
+          "propValue": {
+            "environment": "test",
+            "deployEnabled": false
+          }
+        }, {
+          "propType": "autodeploy.update",
+          "environment": "dev",
+          "deployEnabled": false,
+          "propKey": "autodeploy.update.dev",
+          "propValue": {
+            "environment": "dev",
+            "deployEnabled": false
+          }
+        }, {
+          "propType": "autodeploy.update",
+          "environment": "multinode",
+          "deployEnabled": false,
+          "propKey": "autodeploy.update.multinode",
+          "propValue": {
+            "environment": "multinode",
+            "deployEnabled": false
+          }
+        }, {
+          "propType": "autodeploy.update",
+          "environment": "live",
+          "deployEnabled": false,
+          "propKey": "autodeploy.update.live",
+          "propValue": {
+            "environment": "live",
+            "deployEnabled": false
+          }
+        }],
+        "businessObject": "cluster/reseller/customer/domain/service/cloud-apps",
+        "initialisedFromTemplate": "true",
+        "migrated": false,
+        "internallyHostedRepoUrl": "git@git.ndonnellytest.skunkhenry.com:testing/testds-testds.git",
+        "internallyHostedRepoName": "testds-testds",
+        "pushInfo": {},
+        "openshift": null,
+        "openshift3": null,
+        "scmCommit": "05b987f5045bf4868e3872ed2abe4ce3a48fab14",
+        "hasOwnDb": {
+          "test": false,
+          "dev": false,
+          "multinode": false,
+          "live": false
+        },
+        "wrapperModule": {
+          "test": "fh-nodeapp",
+          "dev": "fh-nodeapp",
+          "multinode": "fh-nodeapp",
+          "live": "fh-nodeapp"
+        },
+        "sourcePathConfigurable": false,
+        "previewable": false,
+        "buildable": false
+      }],
+      "authorEmail": "testing-admin@example.com",
+      "sysGroupFlags": 70111,
+      "sysGroupList": "",
+      "businessObject": "cluster/reseller/customer/domain/service",
+      "migrated": false,
+      "templateId": "other",
+      "jsonTemplateId": "datasource_static",
+      "service": true
+    }
+  }
+};

--- a/test/fixtures/fixture_services.js
+++ b/test/fixtures/fixture_services.js
@@ -1,0 +1,13 @@
+var nock = require('nock');
+
+var serviceFixtures = require('./fixture_service');
+var dataSourceFixtures = require('./appforms/fixture_data_source');
+var mockService = serviceFixtures.get();
+var mockDataSource = dataSourceFixtures.get();
+
+
+module.exports = nock('https://apps.feedhenry.com')
+.get('/box/api/connectors/' + mockService.guid)
+.reply(200, mockService)
+.get('/api/v2/services/' + mockService.apps[0].guid + '/data_sources')
+.reply(200, [mockDataSource]);

--- a/test/unit/fh3/services/test_services.js
+++ b/test/unit/fh3/services/test_services.js
@@ -1,0 +1,21 @@
+var assert = require('assert');
+require('test/fixtures/fixture_services');
+var servicesCmd = require('cmd/fh3/services');
+var serviceFixtures = require('test/fixtures/fixture_service');
+var dataSourceFixtures = require('test/fixtures/appforms/fixture_data_source');
+
+var mockService = serviceFixtures.get();
+var mockDataSource = dataSourceFixtures.get();
+
+
+module.exports = {
+  "It Should List Data Sources For A Service": function(done){
+    servicesCmd({_: ['data-sources', mockService.guid]}, function(err, serviceDataSources){
+      assert.ok(!err, "Expected No Error");
+      //Should be an array of data sources.
+      assert.equal(mockDataSource._id, serviceDataSources[0]._id);
+
+      done();
+    });
+  }
+};


### PR DESCRIPTION
Testing Notes:

Deployed to npm.skunkhenry.com as version 2.5.0-221

Using a service: http://testing.ndonnellytest.skunkhenry.com/#services/deqrvgys6gboumo2fvckur76/apps/deqrvg5r2sfblq2ksgbmjy4i/details

1. Target http://testing.ndonnellytest.skunkhenry.com
2. Run fhc services data-sources deqrvgys6gboumo2fvckur76

It should return a table of data sources associated with the service.