### PR TITLE
RHMAP-4395 undeploy command now in fh2 and fh3

### DIFF
--- a/lib/cmd/fh2/undeploy.js
+++ b/lib/cmd/fh2/undeploy.js
@@ -33,7 +33,10 @@ function undeployApp(appId, deployTarget, appType, cb) {
   };
 
   common.doApiCall(fhreq.getFeedHenryUrl(), "box/srv/1.1/environments/" + deployTarget + "/apps/" + appId + "/undeploy", params, "Error undeploying app: ", function (err, data) {
-    if (err) return cb(err);
+    if (err) {
+      return cb(err);
+    }
+
     log.info("App Undeployed");
     log.silly(data, "undeploy app");
     return cb(err, data);

--- a/lib/cmd/fh3/app/undeploy.js
+++ b/lib/cmd/fh3/app/undeploy.js
@@ -1,0 +1,49 @@
+var log = require("../../../utils/log");
+var ini = require("../../../utils/ini");
+
+module.exports = {
+  'desc': 'Undeploy an app given the domain and environment it is deployed to',
+  'examples': [{
+    cmd: 'fhc app undeploy --id=<app-id> --env=<environment> --domain=<domain>',
+    desc: 'Undeploy <app-id> from environment <environment> in domain <domain>'
+  }],
+  'demand': ['id', 'env'],
+  'alias': {
+    'id': 'i',
+    'env': 'e',
+    'domain': 'd',
+    0: 'id',
+    1: 'env',
+    2: 'domain'
+  },
+  'describe': {
+    'id': 'Unique 24 character GUID of the application to undeploy',
+    'env': 'The ID of the environment from where to undeploy the app',
+    'domain': 'The name of the domain from where to undeploy the app',
+    'embed': 'If this flag is present then {embed: true} will be sent'
+  },
+  'url': function (argv) {
+    return [
+      "api/v2/mbaas/deleteapp",
+      argv.domain || ini.get("domain"),
+      argv.env,
+      argv.id
+    ].join('/');
+  },
+  'method': 'post',
+  preCmd: function (params, cb) {
+    var request = {
+      embed: false,
+      id: params.id,
+      env: params.env,
+      domain: params.domain
+    };
+
+    if (typeof params.embed !== 'undefined') {
+      request.embed = true;
+    }
+
+    log.info("Embed flag set to " + request.embed);
+    return cb(null, request);
+  }
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.3.8",
+  "version": "2.3.9",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.3.8-BUILD-NUMBER",
+  "version": "2.3.9-BUILD-NUMBER",
   "_minPlatformVersion": "3.5.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.3.6
+sonar.projectVersion=2.3.9
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/unit/fh3/app/test_undeploy.js
+++ b/test/unit/fh3/app/test_undeploy.js
@@ -1,0 +1,47 @@
+var undeploy = require('cmd/fh3/app/undeploy.js');
+var assert = require('assert');
+var url = require('url');
+
+module.exports = {
+  'test app undeploy command happy path': function (done) {
+    var params = {
+      env: "dev",
+      domain: "testing",
+      id: "j7hslnrb257zkr4qzjndoqkl"
+    };
+
+    undeploy.preCmd(params, function (err, parsed) {
+      // If embed flag is not set we must send false
+      assert.equal(err, null);
+      assert.equal(parsed.embed, false);
+
+      var queryUrl = undeploy.url(parsed);
+      var urlParts = url.parse(queryUrl);
+
+      // Make sure that the URL is parseable
+      assert.equal(typeof urlParts.pathname, 'string');
+
+      // Make sure it calls the `deleteapp` endpoint
+      assert.equal(urlParts.pathname.indexOf('api/v2/mbaas/deleteapp'), 0);
+      assert.equal(urlParts.pathname.indexOf(params.domain) > 0, true);
+
+      done();
+    });
+  },
+
+  'test app undeploy command with embed flag set': function (done) {
+    var params = {
+      env: "dev",
+      domain: "testing",
+      embed: '',
+      id: "j7hslnrb257zkr4qzjndoqkl"
+    };
+
+    undeploy.preCmd(params, function (err, parsed) {
+      assert.equal(err, null);
+      // If embed flag is not set we must send false
+      assert.equal(parsed.embed, true);
+      done();
+    });
+  }
+};


### PR DESCRIPTION
There are now two different version of the undeploy command:

- `lib/cmd/fh2/undeploy.js` works only with the old Feedhenry v2 Platform
- `lib/cmd/fh3/app/undeploy.js` is the new one that works with Feedhenry v3

The command syntax is:

`fhc app undeploy --id=<app-id> --env=<environment> --domain=<domain>`

ping @wtrocki @wei-lee 