### PR TITLE
[RHMAP-5022] Remove debug logging

### DIFF
--- a/lib/cmd/common/initlocal.js
+++ b/lib/cmd/common/initlocal.js
@@ -128,7 +128,6 @@ function modifyTagsToLocal(appContainer, tagsToModify, localDirectory, cb) {
 function constructContainerFromIndex(indexFile, cb) {
   var outputFile;
   var appContainer = cheerio.load(indexFile);
-  console.log(appContainer.html());
   setBodyToPlaceholder(appContainer, function(err, appContainer) {
     if (err) {
       return cb(err);
@@ -144,8 +143,6 @@ function constructContainerFromIndex(indexFile, cb) {
       }
       var hostRegExp = new RegExp('"host"\\s*:\\s*"' + fhreq.getFeedHenryUrl() + '?"');
       outputFile = appContainer.html().replace(hostRegExp, '"host":"' + localHostUrl() + '"');
-      console.log(hostRegExp);
-      console.log(localHostUrl());
       return cb(err, outputFile, fileList);
     });
   });


### PR DESCRIPTION
Little fix on removing `console.log` I left in accidentally when debugging stuff manually.

Can I get a quick review, @wei-lee or @wtrocki? Does this change need to bump a version? The version bump on the original branch issue wasn't published to npm yet, only automatically to [npm.skunkhenry.com]()