### PR TITLE
[RHMAP-4633] fhc build command has an unfriendly way of specifying branch

### DIFF
--- a/lib/cmd/common/build.js
+++ b/lib/cmd/common/build.js
@@ -119,7 +119,7 @@ function argsToPayload(args) {
 }
 
 /**
- * Mutates the arguments object in order to support --branch --commit --hash, turning them into gitRef
+ * Mutates the arguments object in order to support --branch --commit, turning them into gitRef
  * @param  {Object} args Arguments object
  */
 function mutateGitRefArgs(args) {

--- a/lib/cmd/common/build.js
+++ b/lib/cmd/common/build.js
@@ -1,21 +1,25 @@
 module.exports = build;
 
 build.desc = "Builds a client application";
-build.usage = "\nfhc build app=<app-id> destination=<destination> version=<version> config=<config> keypass=<private-key-password> certpass=<certificate-password> download=<true|false> provisioning=<path-to-provisioning-profile> cordova_version=<cordova version>"
+build.usage = "\nfhc build app=<app-id> destination=<destination> version=<version> config=<config> keypass=<private-key-password> certpass=<certificate-password> download=<true|false> provisioning=<path-to-provisioning-profile> cordova_version=<cordova version> branch=<branch name> commit=<commit hash>"
   + "\nwhere <destination> is one of: android, iphone, ipad, ios(for universal binary), blackberry, windowsphone7, windowsphone (windows phone 8)"
   + "\nwhere <version> is specific to the destination (e.g. Android version 4.0)"
   + "\nwhere <config> is either 'debug' (default), 'distribution', or 'release'"
   + "\nwhere <provisioning> is the path to the provisioning profile"
   + "\nwhere <cordova_version> is for specifying which version of Cordova to use. Currently supported: either 2.2 or 3.3. Only valid for Android for now."
+  + "\nwhere <branch name> is the name of the git branch to build, defaults to 'master'"
+  + "\nwhere <commit hash> is the full hash of the commit to build, if not the head of the branch. Must be used with <branch name>"
   + "\n'keypass' and 'certpass' only needed for 'release' builds"
   + "\n'provisioning' is only optional for iphone or ipad builds";
 
-build.usage_ngui = "\nfhc build project=<project-id> app=<app-id> cloud_app=<cloud-app-id> tag=<tag> destination=<destination> version=<version> config=<config> keypass=<private-key-password> certpass=<certificate-password> download=<true|false> provisioning=<path-to-provisioning-profile> cordova_version=<cordova version>"
+build.usage_ngui = "\nfhc build project=<project-id> app=<app-id> cloud_app=<cloud-app-id> tag=<tag> destination=<destination> version=<version> config=<config> keypass=<private-key-password> certpass=<certificate-password> download=<true|false> provisioning=<path-to-provisioning-profile> cordova_version=<cordova version>  branch=<branch name> commit=<commit hash>"
   + "\nwhere <destination> is one of: android, iphone, ipad, ios(for universal binary), blackberry, windowsphone7, windowsphone (windows phone 8)"
   + "\nwhere <version> is specific to the destination (e.g. Android version 4.0)"
   + "\nwhere <config> is either 'debug' (default), 'distribution', or 'release'"
   + "\nwhere <provisioning> is the path to the provisioning profile"
   + "\nwhere <cordova_version> is for specifying which version of Cordova to use. Currently supported: either 2.2 or 3.3. Only valid for Android for now."
+  + "\nwhere <branch name> is the name of the git branch to build, defaults to 'master'"
+  + "\nwhere <commit hash> is the full hash of the commit to build, if not the head of the branch. Must be used with <branch name>"
   + "\n'keypass' and 'certpass' only needed for 'release' builds"
   + "\n'provisioning' is only optional for iphone or ipad builds";
 
@@ -40,8 +44,10 @@ function build(argv, cb) {
     if (isNGUI) {
       validateArgsNgui(argObj);
     }
+    mutateGitRefArgs(argObj);
     doBuild(argObj, cb);
   } catch (x) {
+    log.silly(x);
     return cb("Error processing args: " + x + "\nUsage: " + isNGUI ? build.usage_ngui : build.usage);
   }
 }
@@ -105,16 +111,42 @@ function validateArgsNgui(args) {
 function argsToPayload(args) {
   var initialPayload = "generateSrc=false";
   return _.reduce(args, function(payload, value, key) {
+    if (_.isObject(value)) {
+      value = JSON.stringify(value);
+    }
     return payload + "&" + key + "=" + value;
   }, initialPayload);
+}
+
+/**
+ * Mutates the arguments object in order to support --branch --commit --hash, turning them into gitRef
+ * @param  {Object} args Arguments object
+ */
+function mutateGitRefArgs(args) {
+  if (args.branch) {
+    args.gitRef = {
+      type: 'branch',
+      value: args.branch
+    };
+  }
+
+  if (args.commit) {
+    if (!args.branch) {
+      throw new Error("commit should be used along with a corresponding branch!");
+    }
+    args.gitRef.hash = args.commit;
+  }
+
+  delete args.branch;
+  delete args.hash;
 }
 
 // do the build..
 function doBuild(args, cb) {
   var uri = "box/srv/1.1/wid/" + fhc.curTarget + "/" + args.destination + "/" + args.app + "/deliver";
-  var doCall = function () {
+  var doCall = function() {
     var payload = argsToPayload(args);
-    common.doApiCall(fhreq.getFeedHenryUrl(), uri, payload, "Error reading app: ", function (err, data) {
+    common.doApiCall(fhreq.getFeedHenryUrl(), uri, payload, "Error reading app: ", function(err, data) {
       if (err) {
         return cb(err);
       }
@@ -122,14 +154,14 @@ function doBuild(args, cb) {
       if (data.cacheKey) keys.push(data.cacheKey);
       //      if(data.stageKey) keys.push(data.stageKey);
       if (keys.length > 0) {
-        async.map(keys, common.waitFor, function (err, results) {
+        async.map(keys, common.waitFor, function(err, results) {
           if (err) {
             return cb(err);
           }
           if (results[0] && results[0][0] && results[0][0].action) {
             var build_asset = results[0][0].action.url;
             build.message = "\nDownload URL: " + build_asset;
-            downloadBuild(args, build_asset, './', function (err, data) {
+            downloadBuild(args, build_asset, './', function(err, data) {
               if (err) {
                 return cb(err);
               }
@@ -159,7 +191,7 @@ function doBuild(args, cb) {
       buildType: args.config,
       templateInstance: args.app
     };
-    fhreq.uploadFile(resourceUrl, args.provisioning, fields, "application/octet-stream", function (err, data) {
+    fhreq.uploadFile(resourceUrl, args.provisioning, fields, "application/octet-stream", function(err, data) {
       if (data.result && data.result === "ok") {
         log.info("Provisioning profile uploaded");
         doCall();
@@ -184,14 +216,14 @@ function downloadBuild(args, assetUrl, path, cb) {
   log.silly(fileName, "download filename");
   log.silly(proto, "download protocol");
 
-  var req = proto.get(uri, function (res) {
+  var req = proto.get(uri, function(res) {
     var closedAlready = false;
     if (res.statusCode !== 200) {
       return cb("Unexpected response code for file download: " + res.statusCode + " message: " + res.body);
     }
 
     var stream = fs.createWriteStream(fileName);
-    res.on('data', function (chunk) {
+    res.on('data', function(chunk) {
       stream.write(chunk);
     });
 
@@ -206,23 +238,23 @@ function downloadBuild(args, assetUrl, path, cb) {
       }
     }
 
-    stream.on('finish', function () {
+    stream.on('finish', function() {
       log.silly('Finish stream event received');
       finishOutoutStream();
     });
 
-    stream.on('close', function () {
+    stream.on('close', function() {
       log.silly('close stream event received');
       finishOutoutStream();
     });
 
-    res.on('end', function () {
+    res.on('end', function() {
       log.silly('End of netork stream received');
       stream.end();
     });
   });
 
-  req.on('error', function (err) {
+  req.on('error', function(err) {
     return cb("Error downloading build: " + err.message);
   });
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.4.1-BUILD-NUMBER",
+  "version": "2.5.0-BUILD-NUMBER",
   "_minPlatformVersion": "3.5.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.4.1
+sonar.projectVersion=2.5.0
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
Adds support for new params `--commit` and `--branch`. It seems millicore can work with only the branch reference, and `commit` is only necessary when specifying a commit that's not on the head of the branch.

ping @wei-lee, @wtrocki, @vchepeli