### PR TITLE
Do not look up the non-JS files

### DIFF
--- a/lib/commandTree.js
+++ b/lib/commandTree.js
@@ -10,7 +10,7 @@ module.exports = function (cb) {
 
   finder.on('file', function (file) {
     var base = path.basename(file);
-    if (base[0] === '.' || base[0] === '_') {
+    if (base[0] === '.' || base[0] === '_' || !base.match(/\.js$/)) {
       return;
     }
     file = file.replace(cmdDir, '');


### PR DESCRIPTION
Editor creates a backup file on editing or there may be some garbage
files under the command tree directories unexpectedly. fhc command
should ignores them on looking up commands.