### PR TITLE
[RHMAP] 4633 - Fix gitref params and add support for tag

### DIFF
--- a/lib/cmd/common/build.js
+++ b/lib/cmd/common/build.js
@@ -1,14 +1,15 @@
 module.exports = build;
 
 build.desc = "Builds a client application";
-build.usage = "\nfhc build app=<app-id> destination=<destination> version=<version> config=<config> keypass=<private-key-password> certpass=<certificate-password> download=<true|false> provisioning=<path-to-provisioning-profile> cordova_version=<cordova version> branch=<branch name> commit=<commit hash>"
+build.usage = "\nfhc build app=<app-id> destination=<destination> version=<version> config=<config> keypass=<private-key-password> certpass=<certificate-password> download=<true|false> provisioning=<path-to-provisioning-profile> cordova_version=<cordova version> git-tag=<tag name> git-branch=<branch name> git-commit=<commit hash>"
   + "\nwhere <destination> is one of: android, iphone, ipad, ios(for universal binary), blackberry, windowsphone7, windowsphone (windows phone 8)"
   + "\nwhere <version> is specific to the destination (e.g. Android version 4.0)"
   + "\nwhere <config> is either 'debug' (default), 'distribution', or 'release'"
   + "\nwhere <provisioning> is the path to the provisioning profile"
   + "\nwhere <cordova_version> is for specifying which version of Cordova to use. Currently supported: either 2.2 or 3.3. Only valid for Android for now."
+  + "\nwhere <tag name> is the name of a tag to be built."
   + "\nwhere <branch name> is the name of the git branch to build, defaults to 'master'"
-  + "\nwhere <commit hash> is the full hash of the commit to build, if not the head of the branch. Must be used with <branch name>"
+  + "\nwhere <commit hash> is the full hash of the commit to build."
   + "\n'keypass' and 'certpass' only needed for 'release' builds"
   + "\n'provisioning' is only optional for iphone or ipad builds";
 
@@ -119,29 +120,61 @@ function argsToPayload(args) {
 }
 
 /**
- * Mutates the arguments object in order to support --branch --commit, turning them into gitRef
+ * Mutates the arguments object in order to support --git-branch --git-commit and --git-tag, turning them into gitRef
  * @param  {Object} args Arguments object
  */
 function mutateGitRefArgs(args) {
-  if (args.branch) {
+  // Workaround for current millicore behavior:
+  // If no git- params are present, build from branch:master
+  var gitParams = [
+    'git-commit',
+    'git-tag',
+    'git-branch'
+  ];
+  if (!_.any(gitParams, _.propertyOf(args))) {
     args.gitRef = {
       type: 'branch',
-      value: args.branch
+      value: 'master'
     };
+    return;
   }
 
-  if (args.commit) {
-    if (!args.branch) {
-      throw new Error("commit should be used along with a corresponding branch!");
-    }
-    args.gitRef.hash = args.commit;
+  function clearGitParams(args) {
+    _.each(gitParams, function(p) {
+      delete args[p];
+    });
   }
 
-  delete args.branch;
-  delete args.hash;
+  // priority is commit > tag > branch
+  if (args['git-commit']) {
+    args.gitRef = {
+      type: 'commit',
+      value: args['git-commit'],
+      hash: args['git-commit']
+    };
+    clearGitParams(args);
+    return;
+  }
+
+  if (args['git-tag']) {
+    args.gitRef = {
+      type: 'tag',
+      value: args['git-tag']
+    };
+    clearGitParams(args);
+    return;
+  }
+
+  if (args['git-branch']) {
+    args.gitRef = {
+      type: 'branch',
+      value: args['git-branch']
+    };
+    clearGitParams(args);
+    return;
+  }
 }
 
-// do the build..
 function doBuild(args, cb) {
   var uri = "box/srv/1.1/wid/" + fhc.curTarget + "/" + args.destination + "/" + args.app + "/deliver";
   var doCall = function() {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.7.0-BUILD-NUMBER",
+  "version": "2.7.1-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.7.0-BUILD-NUMBER",
+  "version": "2.7.1-BUILD-NUMBER",
   "_minPlatformVersion": "3.10.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.7.0
+sonar.projectVersion=2.7.1
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/fixtures/user/fixture_user_read.js
+++ b/test/fixtures/user/fixture_user_read.js
@@ -1,6 +1,6 @@
 var nock = require('nock');
 
-var userReadReply = function(){
+var userReadReply = function() {
   return {
     displayName: 'Foo Bar',
     domain: 'apps',

--- a/test/unit/legacy/test_user.js
+++ b/test/unit/legacy/test_user.js
@@ -1,21 +1,14 @@
 var assert = require('assert');
 var user = require('cmd/common/user.js');
-var userReadNock = require('test/fixtures/user/fixture_user_read.js');
+require('test/fixtures/user/fixture_user_read.js');
 var util = require('util');
 
 module.exports = {
-  setUp : function(cb){
-    return cb();
-  },
   'test user': function(cb) {
     user({ _ : ['']}, function (err, data) {
       assert.equal(err, null, "Err not null: " + util.inspect(err));
       assert.ok(data);
       return cb();
     });
-  },
-  tearDown : function(cb){
-    userReadNock.done();
-    return cb();
   }
 };


### PR DESCRIPTION
# Motivation
Revisiting [RHMAP-4633](https://issues.jboss.org/browse/RHMAP-4633), about improving the interface for specifying a git reference on the `fhc build` command, due to an incomplete initial implementation.

# Changes

* During testing we discovered the back-end is building on top of the previously specified `gitRef` so for now a workaround of defaulting to `master` was added to make running the command deterministic.
* Add a `git-` prefix to the parameters because of collision with `tag`