### PR TITLE
[RHMAP 5595] Reenable delete command for mbaas targets

### DIFF
--- a/lib/cmd/fh3/admin/mbaas/delete.js
+++ b/lib/cmd/fh3/admin/mbaas/delete.js
@@ -1,5 +1,3 @@
-// 2016-04-07: This command was temporarily disabled due to decision of not supporting mbaas deletion
-// until the back-end implements all infrastructure operations required for properly disposing of an MBaaS
 module.exports = {
   'desc' : 'Delete an MBaaS.',
   'examples' : [{ cmd : 'fhc admin mbaas delete --id=<MBaaS id>'}],
@@ -8,7 +6,7 @@ module.exports = {
   'describe' : {
     'id' : 'Some unique MBaaS identifier'
   },
-  'url' : function(params){
+  'url' : function(params) {
     return '/api/v2/mbaases/' + params.id;
   },
   'method' : 'delete'

--- a/test/fixtures/admin/fixture_mbaas.js
+++ b/test/fixtures/admin/fixture_mbaas.js
@@ -1,7 +1,7 @@
 var nock = require('nock');
 
 var envReplies = {
-  crud : function(){
+  crud : function() {
     return {
       status : 'ok',
       _id : '1a',
@@ -9,7 +9,7 @@ var envReplies = {
       targets : ['http://www.1.com', 'http://www.2.com']
     };
   },
-  list : function(){
+  list : function() {
     return [envReplies.crud()];
   }
 };

--- a/test/unit/fh3/admin/test_mbaas.js
+++ b/test/unit/fh3/admin/test_mbaas.js
@@ -6,12 +6,13 @@ var adminmbaas = {
   create : genericCommand(require('cmd/fh3/admin/mbaas/create')),
   read : genericCommand(require('cmd/fh3/admin/mbaas/read')),
   update : genericCommand(require('cmd/fh3/admin/mbaas/update')),
+  delete : genericCommand(require('cmd/fh3/admin/mbaas/delete')),
   list : genericCommand(require('cmd/fh3/admin/mbaas/list'))
 };
 var anMBaaS = {url : 'http://mbaas.com', servicekey : 'svckey', id : '1a2b', username : 'test', password : 'test'};
 module.exports = {
   'test admin-mbaas list': function(cb) {
-    adminmbaas.list(_.clone(anMBaaS), function (err, data){
+    adminmbaas.list(_.clone(anMBaaS), function(err, data) {
       assert.equal(err, null);
       assert.equal(data.length, 1);
       assert.equal(data[0].url, 'http://www.mbaas.com');
@@ -19,21 +20,27 @@ module.exports = {
     });
   },
   'test admin-mbaas read': function(cb) {
-    adminmbaas.read(_.clone(anMBaaS), function (err, data){
+    adminmbaas.read(_.clone(anMBaaS), function(err, data) {
       assert.equal(err, null);
       assert.equal(data.url, 'http://www.mbaas.com');
       return cb();
     });
   },
   'test admin-mbaas create': function(cb) {
-    adminmbaas.create(_.clone(anMBaaS), function (err, data){
+    adminmbaas.create(_.clone(anMBaaS), function(err, data) {
       assert.equal(err, null);
       assert.equal(data.url, 'http://www.mbaas.com');
       return cb();
     });
   },
   'test admin-mbaas update': function(cb) {
-    adminmbaas.update(_.clone(anMBaaS), function (err){
+    adminmbaas.update(_.clone(anMBaaS), function(err) {
+      assert.equal(err, null);
+      return cb();
+    });
+  },
+  'test admin-mbaas delete': function(cb) {
+    adminmbaas.delete(_.clone(anMBaaS), function(err) {
       assert.equal(err, null);
       return cb();
     });


### PR DESCRIPTION
Part of the changes to support the new mbaas targets models.

Reverting the disabling of `fhc admin mbaas delete`, pointing to the same JIRA as the first PR.

ping @pb82 @odra @wei-lee @vchepeli