### PR TITLE
[RHMAP 5796] Revert removal of --noAppend flag

### DIFF
--- a/lib/cmd/fh3/admin/environments/create.js
+++ b/lib/cmd/fh3/admin/environments/create.js
@@ -1,6 +1,8 @@
+var log = require("../../../../utils/log");
+
 module.exports = {
   'desc' : 'Creates an environment.',
-  'examples' : [{ cmd : 'fhc admin environments create --id=<environment id> --label=<label> --target=<mbaasTargetId>',
+  'examples' : [{ cmd : 'fhc admin environments create --id=<environment id> --label=<label> --target=<mbaasTargetId> --noAppend=<boolean>',
     desc : 'Creates an environment'}],
   'demand' : ['id', 'label', 'target'],
   'alias' : {},
@@ -9,7 +11,8 @@ module.exports = {
     'label' : 'A label describing your environment',
     'target' : 'unique identifier for an existing MBaaS Target',
     'autoDeployOnCreate' : 'option used to setup automatic deployment to this environment when creating new project/app.',
-    'autoDeployOnUpdate' : 'option used to setup automatic deployment to this environment when making source code changes within app.'
+    'autoDeployOnUpdate' : 'option used to setup automatic deployment to this environment when making source code changes within app.',
+    'noAppend' : 'option used to create environment without adding it to the list of environments available for the domain.'
   },
   'url' : '/api/v2/environments',
   'method' : 'post',
@@ -28,8 +31,14 @@ module.exports = {
       label: params.label,
       target: params.target,
       autoDeployOnCreate: params.autoDeployOnCreate,
-      autoDeployOnUpdate: params.autoDeployOnUpdate
+      autoDeployOnUpdate: params.autoDeployOnUpdate,
+      noAppend: params.noAppend
     };
+
+    if(params.noAppend) {
+      log.warn("Warning! noAppend flag used. Environment will not appear in environment list. ");
+    }
+
     return cb(null, request);
   }
 };


### PR DESCRIPTION
This parameter is being used by operations, was recently added (#182) and support in supercore was also not removed.

ping @ciaran-byrne @wei-lee

https://issues.jboss.org/browse/RHMAP-5796