### PR TITLE
Fixing fhc git prop set

### DIFF
--- a/lib/cmd/common/git.js
+++ b/lib/cmd/common/git.js
@@ -16,7 +16,8 @@ var Table = require('cli-table');
 // Main git command entry point
 function git(argv, cb) {
   var args = argv._;
-  if (args.length === 0 || args.length > 3) {
+
+  if (args.length === 0 || args.length > 4) {
     return cb(git.usage);
   }
 
@@ -29,7 +30,9 @@ function git(argv, cb) {
     return pull(appId, cb);
   } else if (action === 'set') {
     args.shift();
-    if (args.length === 0 || args.length > 3) return cb(git.usage);
+    if (args.length === 0 || args.length > 3) {
+      return cb(git.usage);
+    }
     appId = fhc.appId(args[0]);
     var name = args[1];
     var value = args[2];
@@ -55,7 +58,7 @@ function props(appId, cb) {
 // Git set properties
 // Note: although we're just setting scm related properties, the app update endpoint expects the full config object..
 function set(appId, k, v, cb) {
-  common.readApp(appId, function (err, cfg) {
+  common.readAppWithoutProject(appId, function (err, cfg) {
     if (err) return cb(err);
 
     // the config object returned from readApp is not the expected format for app/update :-(
@@ -68,14 +71,14 @@ function set(appId, k, v, cb) {
         "height": cfg.inst.height,
         "width": cfg.inst.width,
         "config": cfg.inst.config,
-        "widgetConfig": cfg.app.config
+        "widgetConfig": cfg.inst.config
       },
       "context": {}
     };
 
     // update the payload scm parameters
     var scm;
-    if (cfg.app && cfg.app.config && cfg.app.config.scm) scm = cfg.app.config.scm;
+    if (cfg.inst && cfg.inst.config && cfg.inst.config.scm) scm = cfg.inst.config.scm;
     if (!scm) git.message = "'" + appId + "' is not a Git based Application";
     payload.payload.widgetConfig.scm[k] = v;
 
@@ -97,7 +100,6 @@ function set(appId, k, v, cb) {
 
 // tell FeedHenry to do a 'git pull'
 function pull(appId, cb) {
-
   var payload = {payload: {guid: appId}};
   millicore.widgForAppId(appId, function (err, widgId) {
     common.doApiCall(fhreq.getFeedHenryUrl(), "box/srv/1.1/pub/app/" + widgId + "/refresh", payload, "Error in Git pull: ", function (err, data) {
@@ -117,20 +119,17 @@ function pull(appId, cb) {
 function createTableForProps(scm) {
   var url = scm.url;
   var branch = scm.branch;
-  var key = scm.key;
 
   var branchLen = common.strlen(branch) < 6 ? 8 : common.strlen(branch);
-  var keyLen = common.strlen(key) < 3 ? 5 : common.strlen(key);
-  if (keyLen > common.maxTableCell) keyLen = common.maxTableCell;
 
   // create our table
   git.table = new Table({
-    head: ['Url', 'Branch', 'Key'],
-    colWidths: [common.strlen(url) + 2, branchLen + 2, keyLen + 2],
+    head: ['Url', 'Branch'],
+    colWidths: [common.strlen(url) + 2, branchLen + 2],
     style: common.style()
   });
 
-  git.table.push([url, branch, key]);
+  git.table.push([url, branch]);
 }
 
 // get git properties
@@ -141,7 +140,7 @@ function getGitProps(appId, cb) {
     if (err) return cb(err);
     if (data.status !== 'ok') return cb("Error reading Git properties: " + (data.error || data.msg));
     var scm;
-    if (data.app && data.app.config && data.app.config.scm) scm = data.app.config.scm;
+    if (data.app && data.inst.config && data.inst.config.scm) scm = data.inst.config.scm;
     return cb(err, scm);
   });
 }

--- a/lib/common.js
+++ b/lib/common.js
@@ -687,6 +687,10 @@ function readApp(projectId, appId, cb) {
   }
 }
 
+function readAppWithoutProject(appId, cb) {
+  readApp(null, appId, cb);
+}
+
 // Create a generic 'Name/Value' Table
 function createNVTable(pairs) {
   var nvs = [];
@@ -952,6 +956,7 @@ exports.listProjects = listProjects;
 exports.listServices = listServices;
 exports.listTemplates = listTemplates;
 exports.readApp = readApp;
+exports.readAppWithoutProject = readAppWithoutProject;
 exports.getAppIds = getAppIds;
 exports.getProjectIds = getIds(listProjects);
 exports.getServiceIds = getIds(listServices);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.7.0-BUILD-NUMBER",
+  "version": "2.7.1-BUILD-NUMBER",
   "_minPlatformVersion": "3.10.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.7.0
+sonar.projectVersion=2.7.1
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
`fhc git props` & `fhc git set` have been broken with a while, this patches and fixes the commands.

Some commands to test with below.

Reading git props for an app:

```
fhc git props 6magpwla4zuxssywj77u6o2x
```

Setting a default branch for an app:

```
fhc git set 6magpwla4zuxssywj77u6o2x branch master
```