### PR TITLE
RHMAP-6186 allow to set the editable flag in fhc

### DIFF
--- a/lib/cmd/fh3/admin/mbaas/create.js
+++ b/lib/cmd/fh3/admin/mbaas/create.js
@@ -1,6 +1,6 @@
 module.exports = {
   'desc' : 'Creates an MBaaS.',
-  'examples' : [{ cmd : 'fhc admin mbaas create --id=<MBaaS id> --url=<MBaaS URL> --servicekey=<MBaaS Service Key> --username=<MBaaS User Name> --password=<MBaaS Password> --decoupled=<bool> --size=<MBaaS Size> --label=<MBaaS label>', desc : 'Creates an mbaas'}],
+  'examples' : [{ cmd : 'fhc admin mbaas create --id=<MBaaS id> --url=<MBaaS URL> --servicekey=<MBaaS Service Key> --username=<MBaaS User Name> --password=<MBaaS Password> --decoupled=<bool> --size=<MBaaS Size> --label=<MBaaS label> --editable=<bool>', desc : 'Creates an mbaas'}],
   'demand' : ['id', 'url', 'servicekey', 'username', 'password'],
   'alias' : {},
   'describe' : {
@@ -11,7 +11,8 @@ module.exports = {
     'password' : 'MBaaS Password',
     'decoupled':'flag them mbaas as decoupled',
     'size': 'The size of the MBaaS',
-    'label': 'A label to apply to the MBaaS, defaults to id if not specified'
+    'label': 'A label to apply to the MBaaS, defaults to id if not specified',
+    'editable': 'Determines if the MBaaS target is editable for non-reseller users'
   },
   'url' : '/api/v2/mbaases',
   'method' : 'post',
@@ -25,5 +26,4 @@ module.exports = {
     delete params.$0;
     return cb(null, params);
   }
-
 };

--- a/lib/cmd/fh3/admin/mbaas/update.js
+++ b/lib/cmd/fh3/admin/mbaas/update.js
@@ -1,6 +1,6 @@
 module.exports = {
   'desc' : 'Update an MBaaS.',
-  'examples' : [{ cmd : 'fhc admin mbaas update --id=<MBaaS id> --url=<MBaaS URL> --servicekey=<MBaaS Service Key> --username=<MBaaS User Name> --password=<MBaaS Password> --decoupled=<bool> --size=<MBaaS Size> --label=<MBaaS label>', desc : 'Updates an mbaas with id <mbaasId>'}],
+  'examples' : [{ cmd : 'fhc admin mbaas update --id=<MBaaS id> --url=<MBaaS URL> --servicekey=<MBaaS Service Key> --username=<MBaaS User Name> --password=<MBaaS Password> --decoupled=<bool> --size=<MBaaS Size> --label=<MBaaS label> --editable=<bool>', desc : 'Updates an mbaas with id <mbaasId>'}],
   'demand' : ['id'],
   'alias' : {},
   'describe' : {
@@ -11,7 +11,8 @@ module.exports = {
     'password' : 'MBaaS Password',
     'decoupled':'flag them mbaas as decoupled',
     'size': 'The size of the MBaaS',
-    'label': 'A label to apply to the MBaaS'
+    'label': 'A label to apply to the MBaaS',
+    'editable': 'Determines if the MBaaS target is editable for non-reseller users'
   },
   'url' : function(params) {
     return '/api/v2/mbaases/' + params.id;
@@ -22,5 +23,4 @@ module.exports = {
     delete params.$0;
     return cb(null, params);
   }
-
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.7.1-BUILD-NUMBER",
+  "version": "2.7.2-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.7.1-BUILD-NUMBER",
+  "version": "2.7.2-BUILD-NUMBER",
   "_minPlatformVersion": "3.10.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.7.1
+sonar.projectVersion=2.7.2
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/unit/fh3/admin/test_mbaas.js
+++ b/test/unit/fh3/admin/test_mbaas.js
@@ -9,7 +9,7 @@ var adminmbaas = {
   delete : genericCommand(require('cmd/fh3/admin/mbaas/delete')),
   list : genericCommand(require('cmd/fh3/admin/mbaas/list'))
 };
-var anMBaaS = {url : 'http://mbaas.com', servicekey : 'svckey', id : '1a2b', username : 'test', password : 'test'};
+var anMBaaS = {url : 'http://mbaas.com', servicekey : 'svckey', id : '1a2b', username : 'test', password : 'test', 'editable': true};
 module.exports = {
   'test admin-mbaas list': function(cb) {
     adminmbaas.list(_.clone(anMBaaS), function(err, data) {


### PR DESCRIPTION
# Motivation

fhc must be able to set the `editable` field of MBaaS targtes. This PR adds that ability to the following commands:
`fhc admin mbaas create`
`fhc admin mbaas update`

There was not really a lot to do other than add some doc and examples. The properties are already sent and supercore will use `req.body` to populate the MBaaS target fields.

ping @wei-lee @wtrocki @paolobueno 