### PR TITLE
Reverts npm publish tag to "latest-2".

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "fhc": "./bin/fhc.js"
   },
   "publishConfig": {
-    "tag": "latest-3"
+    "tag": "latest-2"
   },
   "dependencies": {
     "async": "0.2.9",


### PR DESCRIPTION
Undo the change made in "publishConfig" for [RHMAP-6397](https://issues.jboss.org/browse/RHMAP-6397)