### PR TITLE
RHMAP-6497 download file

### DIFF
--- a/lib/cmd/fh3/appdata.js
+++ b/lib/cmd/fh3/appdata.js
@@ -17,6 +17,7 @@ var ini = require('../../utils/ini');
 var _ = require('underscore');
 var templates = require('../common/templates.js');
 var readline = require('readline');
+var fs = require('fs');
 
 var cmdRef = {
   'list': listAppData,
@@ -142,15 +143,26 @@ function downloadAppData(args, cb) {
     return cb(inputError);
   }
 
-  common.doApiCall(fhreq.getFeedHenryUrl(), path, {}, 'Error exporting data: ', onDone);
-
-  function onDone(err, res) {
+  // First get the download URL
+  common.doApiCall(fhreq.getFeedHenryUrl(), path, {}, 'Error retrieving download URL', function (err, res) {
     if (err) {
       return cb(err);
     }
 
-    return cb(null, 'Download URL: ' + res.url);
-  }
+    var params = {};
+    params.url = res.url;
+    params.method = 'GET';
+    params.output = downloadFilePath;
+
+    // Then download the file
+    fs.stat(params.output, function(err) {
+      if (!err) {
+        return cb("The file at path " + params.output + " already exists.");
+      }
+
+      fhreq.downloadFile(params, cb);
+    });
+  });
 }
 
 function unknown(message, cb) {


### PR DESCRIPTION
Use the `fhc appdata download` command to download the exported file.

No version bump because one version bump for the whole feature branch should be enough.

ping @odra 