### PR TITLE
RHMAP-6712 add export read and status commands

### DIFF
--- a/lib/cmd/fh3/appdata/export/read.js
+++ b/lib/cmd/fh3/appdata/export/read.js
@@ -1,0 +1,27 @@
+"use strict";
+
+var fs = require('fs')
+  , fhreq = require('../../../../utils/request.js')
+  , async = require('async')
+  , common = require('../../../../common');
+
+module.exports = {
+  'desc': 'Return the whole job definition in JSON format',
+  'examples': [{
+    cmd: [
+      'fhc addpata export read --appId=5ujx2eifvzaudq43nw4nmvcu --envId=live --jobId=5731da1dd3e2b283203c4054'
+    ].join(''),
+    desc: 'Return the whole job definition in JSON format'
+  }],
+  'demand': ['envId', 'appId', 'jobId'],
+  'alias': {},
+  'describe': {
+    'envId': 'Environment id',
+    'appId': 'Application id',
+    'jobId': 'Export job id'
+  },
+  'method': 'get',
+  'url': function (params) {
+    return 'api/v2/appdata/' + params.envId + '/' + params.appId + '/export/data/' + params.jobId;
+  }
+};

--- a/lib/cmd/fh3/appdata/export/start.js
+++ b/lib/cmd/fh3/appdata/export/start.js
@@ -44,7 +44,14 @@ module.exports = {
         return cb(err);
       }
 
-      return cb(null, 'Created a new export job with ID: ' + result);
+      var info = [
+        'Created a new export job with ID: ' + result,
+        '. To check on the job status you can use the following command: \n',
+        'fhc appdata export status --envId=' + params.envId,
+        ' --appId=' + params.appId + ' --jobId=' + result
+      ].join('');
+
+      return cb(null, info);
     });
   }
 };

--- a/lib/cmd/fh3/appdata/export/status.js
+++ b/lib/cmd/fh3/appdata/export/status.js
@@ -1,0 +1,127 @@
+"use strict";
+
+var fs = require('fs')
+  , _ = require('underscore')
+  , fhreq = require('../../../../utils/request.js')
+  , async = require('async')
+  , ProgressBar = require('progress')
+  , common = require('../../../../common');
+
+var POLL_INTERVAL = 2000;
+var MIN_INTERVAL = 100;
+var EXIT_KEYS = ['q', 'Q'];
+
+/**
+ * Read progress information by calling the `read` endpoint to get the
+ * job definition. Progress information is included there:
+ * - step: current export job step
+ * - totalSteps: total export steps
+ */
+function readProgress(params, cb) {
+  var url = 'api/v2/appdata/' + params.envId + '/' + params.appId + '/export/data/' + params.jobId;
+  common.doGetApiCall(fhreq.getFeedHenryUrl(), url, 'Error reading progress', cb);
+}
+
+/**
+ * Update the progressbar if possible. Don't use `bar#tick` as that will not
+ * set the current progress but add the new valud to the current progress.
+ */
+function printout(data, bar) {
+  if (bar && data.totalSteps && data.step >= 0) {
+    bar.update(data.step / data.totalSteps);
+  } else {
+    /* eslint disable-next-line no-console */
+    console.log('No progress information in response');
+  }
+}
+
+/**
+ * Get a sane poll interval (use the default one if the user did not provide
+ * one)
+ */
+function getPollInterval(params) {
+  if (params.interval && _.isNumber(params.interval)) {
+    var interval = params.interval;
+    return interval >= MIN_INTERVAL ? interval : POLL_INTERVAL;
+  } else {
+    return POLL_INTERVAL;
+  }
+}
+
+module.exports = {
+  'desc': 'Poll for job status',
+  'examples': [{
+    cmd: [
+      'fhc addpata export status --appId=5ujx2eifvzaudq43nw4nmvcu --envId=live --jobId=5731da1dd3e2b283203c4054'
+    ].join(''),
+    desc: 'Poll for job status'
+  }],
+  'demand': ['envId', 'appId', 'jobId'],
+  'alias': {},
+  'describe': {
+    'envId': 'Environment id',
+    'appId': 'Application id',
+    'jobId': 'Export job id',
+    'interval': 'Polling interval in milliseconds (default is 2000)'
+  },
+  'method': 'get',
+  'customCmd': function (params, cb) {
+    var bar = null, poller = null;
+
+    function cleanupAndExit() {
+      if (poller) {
+        clearInterval(poller);
+      }
+      return cb(null);
+    }
+
+    // Need to use `console#log` here until we introduce some other logging or outpur
+    // framework to fhc
+    /* eslint disable-next-line no-console */
+    console.log('Polling job progress. Press `q` to quit');
+
+    function getProgressBar(job) {
+      if (bar === null && job.totalSteps) {
+        bar = new ProgressBar('Job progress: [:bar] :current/:total :percent :elapseds :etas', {
+          total: job.totalSteps
+        });
+      }
+      return bar;
+    }
+
+    function onInterval() {
+      readProgress(params, function (err, job) {
+        if (err) {
+          return cleanupAndExit();
+        }
+
+        // supercore sends the actual result in the `data` field
+        job = job.data;
+        printout(job, getProgressBar(job));
+
+        if (bar && bar.complete) {
+          return cleanupAndExit();
+        }
+      });
+    }
+
+    // To circumvent the initial delay
+    onInterval();
+    poller = setInterval(onInterval, getPollInterval(params));
+
+    // Raw mode is required to flush stdin without
+    // pressing return
+    process.stdin.setRawMode(true);
+    process.stdin.on('readable', function () {
+      var chunk = process.stdin.read();
+
+      // `stdin#read` can return null
+      if (chunk) {
+        var letter = chunk.toString();
+        if (EXIT_KEYS.indexOf(letter) >= 0) {
+          return cleanupAndExit();
+        }
+      }
+    });
+  }
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.7.5-BUILD-NUMBER",
+  "version": "2.7.6-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.9",
@@ -235,6 +235,11 @@
       "from": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz"
     },
+    "progress": {
+      "version": "1.1.8",
+      "from": "progress@*",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
+    },
     "request": {
       "version": "2.11.4",
       "from": "https://registry.npmjs.org/request/-/request-2.11.4.tgz",
@@ -339,17 +344,17 @@
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "from": "isarray@0.0.1",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.7.5-BUILD-NUMBER",
+  "version": "2.7.6-BUILD-NUMBER",
   "_minPlatformVersion": "3.10.0",
   "keywords": [
     "feedhenry"
@@ -35,6 +35,7 @@
     "nopt": "1.0.0",
     "once": "^1.3.2",
     "open": "0.0.5",
+    "progress": "^1.1.8",
     "request": "2.11.4",
     "semver": "4.3.6",
     "tabtab": "0.0.2",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.7.5
+sonar.projectVersion=2.7.6
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
# Motivation

Create `read` and `status` commands for appdata export in fhc. `read` will just return the job definition as JSON. `status` will do a realtime polling of the job status until it's finished or the user aborts. The syntax is:

`fhc appdata export read`
`fhc appdata export status`

`status` will print and update a progress bar. I decided to use the not-so-fance `progress` packate instead of the more-fance `node-progress-bars` because the former one does not have any additional dependencies.

ping @odra @paolobueno @wei-lee 