### PR TITLE
RHMAP-6917 make stopApp overridable in the appdata export start command

### DIFF
--- a/lib/cmd/fh3/appdata/export/start.js
+++ b/lib/cmd/fh3/appdata/export/start.js
@@ -10,14 +10,26 @@ module.exports = {
   'examples': [{
     cmd: 'fhc addpata export start --appId=5ujx2eifvzaudq43nw4nmvcu --envId=live',
     desc: 'Start a new data export job for the given application in the given environment'
+  }, {
+    cmd: 'fhc addpata export start --appId=5ujx2eifvzaudq43nw4nmvcu --envId=live --stopApp',
+    desc: 'Start a new data export job and stop the app without asking'
+  }, {
+    cmd: 'fhc addpata export start --appId=5ujx2eifvzaudq43nw4nmvcu --envId=live --stopApp=n',
+    desc: 'Start a new data export job without stopping the app'
   }],
   'demand': ['envId', 'appId'],
   'alias': {},
   'describe': {
     'envId': 'Environment id',
-    'appId': 'Application id'
+    'appId': 'Application id',
+    'stopApp': "override the stop-application prompt"
   },
   'preCmd': function (params, cb) {
+    if (params.stopApp) {
+      params.stopApp = shouldStopApp(params.stopApp);
+      return cb(null, params);
+    }
+
     var rl = readline.createInterface({
       input: process.stdin,
       output: process.stdout

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.7.6-BUILD-NUMBER",
+  "version": "2.7.7-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.7.6-BUILD-NUMBER",
+  "version": "2.7.7-BUILD-NUMBER",
   "_minPlatformVersion": "3.10.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.7.6
+sonar.projectVersion=2.7.7
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
# Motivation

The `start` command prompts the user wether the app should be stopped before exporting or not. This should be overridable by passing a flag (`--stopApp`) to not interfere with automation.

Also the commands should honor the `--json` flag where applicable (`list` and `read`). This is already given (`read` always returns json).

ping @wei-lee 