### PR TITLE
RHMAP-7117 remove url and expires cols

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -843,7 +843,7 @@ function createRuntimeTable(data) {
  */
 exports.createTableForAppData = function(appDataList){
   var table = new Table({
-    head: ['Job ID', 'App ID', 'Environment', 'Status', 'Download URL', 'Expires On'],
+    head: ['Job ID', 'App ID', 'Environment', 'Status'],
     style: exports.style()
   });
 
@@ -854,11 +854,8 @@ exports.createTableForAppData = function(appDataList){
     var appId = data.appid;
     var env = data.environment;
     var status = data.status;
-    var filePath = data.filePath;
-    var downloadUrl = 'http://' + env + '.feedhenry.me/' + appId + filePath;
-    var expiresOn = '2016-12-05 12:00:00 AM';
 
-    table.push([jobId, appId, env, status, downloadUrl, expiresOn]);
+    table.push([jobId, appId, env, status]);
   });
 
   return table;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.7.7-BUILD-NUMBER",
+  "version": "2.7.8-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.7.7-BUILD-NUMBER",
+  "version": "2.7.8-BUILD-NUMBER",
   "_minPlatformVersion": "3.10.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.7.7
+sonar.projectVersion=2.7.8
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
# Motivation

The `Download URL` and `Expires` columns should not be shown in the output. The `Download URL` is not useful and the `Expires` contained hardcoded data (and will only make sense once the file-cleanup job is in place.

ping @wei-lee @ziccardi 