### PR TITLE
RHMAP-7316

### DIFF
--- a/lib/cmd/fh3/appdata/export/status.js
+++ b/lib/cmd/fh3/appdata/export/status.js
@@ -68,11 +68,11 @@ module.exports = {
   'customCmd': function (params, cb) {
     var bar = null, poller = null;
 
-    function cleanupAndExit() {
+    function cleanupAndExit(err) {
       if (poller) {
         clearInterval(poller);
       }
-      return cb(null);
+      return cb(err);
     }
 
     // Need to use `console#log` here until we introduce some other logging or outpur
@@ -92,7 +92,7 @@ module.exports = {
     function onInterval() {
       readProgress(params, function (err, job) {
         if (err) {
-          return cleanupAndExit();
+          return cleanupAndExit(err);
         }
 
         // supercore sends the actual result in the `data` field

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.9.0-BUILD-NUMBER",
+  "version": "2.9.1-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.9.0-BUILD-NUMBER",
+  "version": "2.9.1-BUILD-NUMBER",
   "_minPlatformVersion": "3.10.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.9.0
+sonar.projectVersion=2.9.1
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
## Motivation

When an error was returned from mbaas during the polling of the status of an export job, the polling was interrupted, but no error message was visualized.
