### PR TITLE
Rhmap 4442 fhc keypass parameter does not work for fhc build ios debug

### DIFF
--- a/lib/cmd/common/build.js
+++ b/lib/cmd/common/build.js
@@ -85,8 +85,12 @@ function validateArgs(args) {
     if (!args.keypass) {
       throw new Error(i18n._("Missing 'keypass' parameter"));
     }
-    args.privateKeyPass = args.keypass; // naff..
+
+    if (!args.certpass) {
+      throw new Error(i18n._("Missing 'certpass' parameter"));
+    }
   }
+  args.privateKeyPass = args.keypass; // naff..
 
   if (buildForIos(args)) {
     args.deviceType = args.destination;


### PR DESCRIPTION
@wei-lee @pb82 
[RHMAP-4442](https://issues.jboss.org/browse/RHMAP-4442)

moved   `args.privateKeyPass = args.keypass;` line so its ran for every build type

probably will need rebase with version bump after other fhc PRs are merged