### PR TITLE
Rhmap 9456 missing credential field

### DIFF
--- a/lib/cmd/common/build.js
+++ b/lib/cmd/common/build.js
@@ -48,7 +48,9 @@ function build(argv, cb) {
       validateArgsNgui(argObj);
     }
     mutateGitRefArgs(argObj);
-    doBuild(argObj, cb);
+    addCredentialsParams(argObj, function(){
+      doBuild(argObj, cb);
+    });
   } catch (x) {
     log.silly(x);
     return cb(i18n._("Error processing args: ") + x + "\n" + i18n._("Usage: ") + isNGUI ? build.usage_ngui : build.usage);
@@ -195,6 +197,23 @@ function mutateGitRefArgs(args) {
   }
 }
 
+function addCredentialsParams(args, cb) {
+  //Fix missing creds names - RHMAP-9456
+  if (args.bundleId) {
+    common.findCredentialsByID(args.bundleId, function(err, data) {
+      if (!err) {
+        //If this is not set its just set as blank
+        if (data.bundleName) {
+          args.credentialName = data.bundleName;
+        }
+      }
+      return cb();
+    });
+  }else{
+    return cb();
+  }
+}
+
 function doBuild(args, cb) {
   var uri = "box/srv/1.1/wid/" + fhc.curTarget + "/" + args.destination + "/" + args.app + "/deliver";
   var doCall = function() {
@@ -235,7 +254,6 @@ function doBuild(args, cb) {
       }
     });
   };
-
   if (!isNGUI() && buildForIos(args) && args.provisioning) {
     var resourceUrl = "/box/srv/1.1/dev/account/res/upload";
     var fields = {

--- a/lib/common.js
+++ b/lib/common.js
@@ -984,6 +984,19 @@ function endsWith(str, suffix) {
   return str.indexOf(suffix, str.length - suffix.length) !== -1;
 }
 
+function findCredentialsByID(id, cb) {
+  exports.doGetApiCall(fhreq.getFeedHenryUrl(), "box/api/credentials", i18n._("Error reading credentials: "), function(err, data) {
+    if (err) {
+      return cb(err);
+    }
+    var result = _.find(data, function(o) {
+      return o.id === id;
+    });
+
+    return cb(null, result);
+  });
+}
+
 exports.createNVTable = createNVTable;
 exports.createObjectTable = createObjectTable;
 exports.createTableForAppProps = createTableForAppProps;
@@ -1003,3 +1016,4 @@ exports.createRuntimeTable = createRuntimeTable;
 exports.maxField = maxField;
 exports.createTableFromArray = createTableFromArray;
 exports.endsWith = endsWith;
+exports.findCredentialsByID = findCredentialsByID;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.12.0-BUILD-NUMBER",
+  "version": "2.12.1-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.11.3
+sonar.projectVersion=2.12.1
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
When using fhc to build apps (`fhc build`) it results in the "credential" field in studio build history being left empty. If you complete the same build via the studio UI the field is populated. This is due to the credentialName param not being populated in FHC.

Had to create a lookup to find it. Thought about allowing the user to specific the param itself but I think it would be confusing to allow the user to call the credential whatever they wanted.