### PR TITLE
RHMAP-9554 Update environment commands to accept token

### DIFF
--- a/lib/cmd/fh3/admin/environments/create.js
+++ b/lib/cmd/fh3/admin/environments/create.js
@@ -1,5 +1,7 @@
 /* globals i18n */
 
+var mbaasTokenCheck = require("../../../../utils/mbaas-token-check");
+
 module.exports = {
   'desc' : i18n._('Creates an environment.'),
   'examples' : [{ cmd : 'fhc admin environments create --id=<environment id> --label=<label> --target=<mbaasTargetId> --token=<token>',
@@ -10,7 +12,7 @@ module.exports = {
     'id' : i18n._('Unique identifier for your environment'),
     'label' : i18n._('A label describing your environment'),
     'target' : i18n._('unique identifier for an existing MBaaS Target'),
-    'token' : i18n._('OpenShift token required to create an OpenShift environment project'),
+    'token' : i18n._('OpenShift token required to create an OpenShift environment project (can be obtained from OpenShift at /oauth/token/request)'),
     'autoDeployOnCreate' : i18n._('option used to setup automatic deployment to this environment when creating new project/app.'),
     'autoDeployOnUpdate' : i18n._('option used to setup automatic deployment to this environment when making source code changes within app.')
   },
@@ -34,6 +36,7 @@ module.exports = {
       autoDeployOnCreate: params.autoDeployOnCreate,
       autoDeployOnUpdate: params.autoDeployOnUpdate
     };
-    return cb(null, request);
+
+    return mbaasTokenCheck.check(request, cb);
   }
 };

--- a/lib/cmd/fh3/admin/environments/create.js
+++ b/lib/cmd/fh3/admin/environments/create.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   'desc' : i18n._('Creates an environment.'),
-  'examples' : [{ cmd : 'fhc admin environments create --id=<environment id> --label=<label> --target=<mbaasTargetId>',
+  'examples' : [{ cmd : 'fhc admin environments create --id=<environment id> --label=<label> --target=<mbaasTargetId> --token=<token>',
     desc : i18n._('Creates an environment')}],
   'demand' : ['id', 'label', 'target'],
   'alias' : {},
@@ -10,6 +10,7 @@ module.exports = {
     'id' : i18n._('Unique identifier for your environment'),
     'label' : i18n._('A label describing your environment'),
     'target' : i18n._('unique identifier for an existing MBaaS Target'),
+    'token' : i18n._('OpenShift token required to create an OpenShift environment project'),
     'autoDeployOnCreate' : i18n._('option used to setup automatic deployment to this environment when creating new project/app.'),
     'autoDeployOnUpdate' : i18n._('option used to setup automatic deployment to this environment when making source code changes within app.')
   },
@@ -29,6 +30,7 @@ module.exports = {
       id: params.id,
       label: params.label,
       target: params.target,
+      token: params.token,
       autoDeployOnCreate: params.autoDeployOnCreate,
       autoDeployOnUpdate: params.autoDeployOnUpdate
     };

--- a/lib/cmd/fh3/admin/environments/update.js
+++ b/lib/cmd/fh3/admin/environments/update.js
@@ -1,13 +1,14 @@
 /* globals i18n */
 module.exports = {
   'desc' : i18n._('Update an environments.'),
-  'examples' : [{ cmd : 'fhc admin environments update --id=<environment id> --label=<label> --target=<mbaasTargetId>', desc : i18n._('Update an environment by id')}],
+  'examples' : [{ cmd : 'fhc admin environments update --id=<environment id> --label=<label> --target=<mbaasTargetId> --token=<token>', desc : i18n._('Update an environment by id')}],
   'demand' : ['id'],
   'alias' : {},
   'describe' : {
     'id' : i18n._('Some unique identifier for your environment'),
     'label' : i18n._('A label describing your environment'),
-    'target' : i18n._('unique identifier for an existing MBaaS Target')
+    'target' : i18n._('unique identifier for an existing MBaaS Target'),
+    'token': i18n._('Openshift token required to create the environment project')
   },
   'url' : function(params) {
     return '/api/v2/environments/' + params.id;
@@ -18,6 +19,7 @@ module.exports = {
       id : params.id, // used in the url function, but discarded from body SS
       label : params.label,
       target : params.target,
+      token: params.token,
       autoDeployOnCreate : params.autoDeployOnCreate,
       autoDeployOnUpdate : params.autoDeployOnUpdate
     });

--- a/lib/cmd/fh3/admin/environments/update.js
+++ b/lib/cmd/fh3/admin/environments/update.js
@@ -1,4 +1,7 @@
 /* globals i18n */
+
+var mbaasTokenCheck = require("../../../../utils/mbaas-token-check");
+
 module.exports = {
   'desc' : i18n._('Update an environments.'),
   'examples' : [{ cmd : 'fhc admin environments update --id=<environment id> --label=<label> --target=<mbaasTargetId> --token=<token>', desc : i18n._('Update an environment by id')}],
@@ -8,21 +11,22 @@ module.exports = {
     'id' : i18n._('Some unique identifier for your environment'),
     'label' : i18n._('A label describing your environment'),
     'target' : i18n._('unique identifier for an existing MBaaS Target'),
-    'token': i18n._('Openshift token required to create the environment project')
+    'token': i18n._('OpenShift token required to create the environment project')
   },
   'url' : function(params) {
     return '/api/v2/environments/' + params.id;
   },
   'method' : 'put',
   'preCmd' : function(params, cb) {
-    return cb(null, {
+    var request = {
       id : params.id, // used in the url function, but discarded from body SS
       label : params.label,
       target : params.target,
       token: params.token,
       autoDeployOnCreate : params.autoDeployOnCreate,
       autoDeployOnUpdate : params.autoDeployOnUpdate
-    });
-  }
+    };
 
+    return mbaasTokenCheck.check(request, cb);
+  }
 };

--- a/lib/utils/mbaas-token-check.js
+++ b/lib/utils/mbaas-token-check.js
@@ -11,7 +11,10 @@ module.exports = {
       }
       // Ensure that a token is provided if creating an openshift3 environment
       if (response.type === 'openshift3' && typeof request.token === 'undefined') {
-        return cb(i18n._('OpenShift environments require a token to be provided'));
+        return cb(i18n._('OpenShift targets require a token to be provided'));
+      }
+      if (response.type === 'feedhenry' && request.token) {
+        return cb(i18n._('FeedHenry targets do not accept tokens'));
       }
 
       return cb(null, request);

--- a/lib/utils/mbaas-token-check.js
+++ b/lib/utils/mbaas-token-check.js
@@ -1,0 +1,20 @@
+var _ = require('underscore');
+var common = require("../common");
+var fhreq = require("./request");
+
+module.exports = {
+  check: function(request, cb) {
+    var url = '/api/v2/mbaases/' + request.target;
+    common.doGetApiCall(fhreq.getFeedHenryUrl(), url, i18n._('Error checking MBaaS type'), function(err, response) {
+      if (err) {
+        return cb(err);
+      }
+      // Ensure that a token is provided if creating an openshift3 environment
+      if (response.type === 'openshift3' && typeof request.token === 'undefined') {
+        return cb(i18n._('OpenShift environments require a token to be provided'));
+      }
+
+      return cb(null, request);
+    });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.12.1-BUILD-NUMBER",
+  "version": "2.13.0-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/test/fixtures/admin/fixture_mbaas.js
+++ b/test/fixtures/admin/fixture_mbaas.js
@@ -1,4 +1,5 @@
 var nock = require('nock');
+var data = require('./environments');
 
 var envReplies = {
   crud : function() {
@@ -27,4 +28,13 @@ module.exports = nock('https://apps.feedhenry.com')
 .delete('/api/v2/mbaases/1a2b', '*')
 .reply(200, envReplies.crud)
 .get('/api/v2/mbaases', '*')
-.reply(200, envReplies.list);
+.reply(200, envReplies.list)
+//Required for the environments tests
+.get('/api/v2/mbaases/testTarget1', '*')
+.reply(200, data[0])
+.get('/api/v2/mbaases/testTarget2', '*')
+.reply(200, data[1])
+.get('/api/v2/mbaases/testTarget1', '*')
+.reply(200, data[0])
+.get('/api/v2/mbaases/testTarget1', '*')
+.reply(200, data[0]);

--- a/test/unit/fh3/admin/test_environments_commands.js
+++ b/test/unit/fh3/admin/test_environments_commands.js
@@ -4,6 +4,9 @@ var environments = require('test/fixtures/admin/environments');
 module.exports = {
   'test admin environments create command': function(cb) {
     environments.forEach(function(env) {
+      // Set target to `id` to avoid calls to /api/v2/mbaases/[Object] in
+      // check in `lib/utils/mbaas-token-check.js`
+      env.target = env.target.id;
       create.preCmd(env, function(_, entity) {
         assert.equal(entity.id, env.id);
       });


### PR DESCRIPTION
Currently the environment commands do not accept the `token` which
will soon be used while creating environments.

This adds the `token` option to the `create` and `update` commands.

An example of creating an environment is now as follows:
```
fhc admin environments create --id=example --label=example --target=OpenShiftTarget --token=example
```


* Point fhcap at a cluster. 
  - For example, `fhcap target http://testing.eng1.skunkhenry.com/ <username> <password>`


* Create an environment and ensure token is sent in payload using `Wireshark` or something.
  - For example, `fhcap admin environments create --id=rhmap9554 --label=rhmap9554 --target=osm3 --token=<token>`


* Update an environment and ensure token is sent in payload using `Wireshark` or something.
  - For example, `fhcap admin environments update --id=rhmap9554 --label=updated --target=osm3 --token=<token>`


* Delete an environment. (Not really needed, just to clean up)
  - For example, `fhcap admin environments delete --id=rhmap9554`