### PR TITLE
RHMAP-10037 Fix environment project creation in OpenShift

### DIFF
--- a/lib/utils/mbaas-token-check.js
+++ b/lib/utils/mbaas-token-check.js
@@ -2,22 +2,30 @@ var _ = require('underscore');
 var common = require("../common");
 var fhreq = require("./request");
 
-module.exports = {
-  check: function(request, cb) {
-    var url = '/api/v2/mbaases/' + request.target;
-    common.doGetApiCall(fhreq.getFeedHenryUrl(), url, i18n._('Error checking MBaaS type'), function(err, response) {
-      if (err) {
-        return cb(err);
-      }
-      // Ensure that a token is provided if creating an openshift3 environment
-      if (response.type === 'openshift3' && typeof request.token === 'undefined') {
-        return cb(i18n._('OpenShift targets require a token to be provided'));
-      }
-      if (response.type === 'feedhenry' && request.token) {
-        return cb(i18n._('FeedHenry targets do not accept tokens'));
-      }
+function checkMbaasType(request, cb) {
+  var url = '/api/v2/mbaases/' + request.target;
+  common.doGetApiCall(fhreq.getFeedHenryUrl(), url, i18n._('Error checking MBaaS type'), function checkIfTokenRequired(err, response) {
+    if (err) {
+      return cb(err);
+    }
 
-      return cb(null, request);
-    });
-  }
+    if (response.type === 'openshift3') {
+      request.targetType = 'openshift3';
+    }
+
+    // Ensure that a token is provided if creating an openshift3 environment
+    if (response.type === 'openshift3' && typeof request.token === 'undefined') {
+      return cb(i18n._('OpenShift targets require a token to be provided'));
+    }
+
+    if (response.type === 'feedhenry' && request.token) {
+      return cb(i18n._('FeedHenry targets do not accept tokens'));
+    }
+
+    return cb(null, request);
+  });
+};
+
+module.exports = {
+  check: checkMbaasType
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.12.1-BUILD-NUMBER",
+  "version": "2.13.1-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.13.0-BUILD-NUMBER",
+  "version": "2.13.1-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.12.1
+sonar.projectVersion=2.13.1
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
Currently when an environment is created through `fhc` the corresponding
environment project is not created.

This is because of the missing `targetType` key on the request to `fh-supercore`.

This adds the `targetType` of `openshift3` when the mbaas is discovered to have
been an OpenShift 3 on in the pre-request check.