### PR TITLE
Add Request ID To Error Output

### DIFF
--- a/lib/genericCommand.js
+++ b/lib/genericCommand.js
@@ -65,11 +65,11 @@ function _handleRequestGenerically(params, cb) {
 
   request(opts, function (err, response, body) {
     if (err) {
-      return cb(err.toString());
+      return cb(fhreq.createErrorMessage(err, response, body));
     }
 
     if (response.statusCode.toString()[0] !== '2') {
-      var msg = fhreq.createErrorMessage(response.statusCode, body);
+      var msg = fhreq.createErrorMessage(err, response, body);
       return cb(msg);
     }
     return cb(null, body);

--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -5,6 +5,7 @@ var cbCalled = false;
 var log = require("./log");
 var fhc = require("../fhc");
 var rm = require("./rm-rf");
+var util = require('util');
 var constants = require("constants");
 var itWorked = false;
 
@@ -19,6 +20,19 @@ process.on("exit", function (code) {
   }
   itWorked = false; // ready for next exit
 });
+
+/**
+ * Ensuring that an error is logged with a request ID if it is present.
+ * @param errorToLog - The error to log.
+ */
+function logReqError(errorToLog) {
+  if (errorToLog && errorToLog.requestId) {
+    log.error(errorToLog);
+    log.error(util.format(i18n._("Request ID: "), errorToLog.requestId));
+  } else {
+    log.error(errorToLog);
+  }
+}
 
 function errorHandler(er) {
   if (cbCalled) throw new Error(i18n._("Callback called more than once."));
@@ -39,13 +53,13 @@ function errorHandler(er) {
   }
   switch (er.errno) {
     case constants.ECONNREFUSED:
-      log.error(er);
+      logReqError(er);
       log.error([i18n._("Connection refused!"),
                  i18n._("Check if your target server is reachable and you have v")
                 ].join("\n"));
       break;
     default:
-      log.error(er);
+      logReqError(er);
       break;
   }
 

--- a/lib/utils/request.js
+++ b/lib/utils/request.js
@@ -31,30 +31,42 @@ var async = require('async');
 
 /**
  * Function To Generate A Relevant Error Message
- * @param statusCode - HTTP Code For The Error Message
+ * @param err          - Error from requestJS
+ * @param httpResponse - HTTP Response
  * @param body - Error Response Body
  */
-function createErrorMessage(statusCode, body){
+function createErrorMessage(err, httpResponse, body){
+  var requestId = httpResponse ?  httpResponse.headers['X-FH-REQUEST-ID'] || httpResponse.headers['x-fh-request-id'] : null;
+  var statusCode = httpResponse ? httpResponse.statusCode : null;
 
-  var msg = util.format(i18n._('Error - not 2xx status code. (%s)\n'), statusCode);
-
-  //If the body is a string, try to parse it as an object.
-  if(_.isString(body)){
-    try {
-      body = JSON.parse(body);
-    } catch(e){
-      body = null;
-    }
-  }
-
-  if(body && body.userDetail){
-    msg +=  body.code + " - " + body.userDetail + "\n";
-    msg += body.systemDetail;
+  if(err && requestId) {
+    err.requestId = requestId;
+    return err;
   } else {
-    msg += JSON.stringify(body);
+    var msg = util.format(i18n._('Error - not 2xx status code. (%s)\n'), statusCode);
+
+    //If the body is a string, try to parse it as an object.
+    if(_.isString(body)){
+      try {
+        body = JSON.parse(body);
+      } catch(e){
+        body = null;
+      }
+    }
+
+    if(body && body.userDetail){
+      msg +=  body.code + " - " + body.userDetail + "\n";
+      msg += body.systemDetail;
+    } else {
+      msg += JSON.stringify(body);
+    }
+
+    var error = new Error(msg);
+
+    error.requestId = requestId;
   }
 
-  return msg;
+  return error;
 }
 
 function request(){}
@@ -161,7 +173,7 @@ function doRequest (fhurl, method, where, what, etag, nofollow, cb_) {
     }
 
     if (response.statusCode.toString()[0]!=='2'){
-      return cb(createErrorMessage(response.statusCode, body));
+      return cb(createErrorMessage(error, response, body));
     }
 
     __stats__.duration = Date.now() - startTime;
@@ -199,6 +211,11 @@ function doRequest (fhurl, method, where, what, etag, nofollow, cb_) {
       }
 
     }
+
+    if(er) {
+      er = createErrorMessage(er, response, body);
+    }
+
     return cb(er, parsed, data, response);
   });
 
@@ -246,13 +263,13 @@ function MULTIGET (fhurls, where, cb) {
  * @access private
  */
 function uploadHandlerFor(cb) {
-  return function(err, response) {
+  return function(err, response, body) {
     if(err) {
       return cb(i18n._("Error Uploading File") + " " + err);
     }
 
     if (response.statusCode.toString()[0]!=='2') {
-      return cb(i18n._("Error - non 2xx status code: ") + response.statusCode + " " + response.body);
+      return cb(createErrorMessage(null, response, body));
     }
 
     return cb();

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.13.1-BUILD-NUMBER",
+  "version": "2.14.0-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.13.1-BUILD-NUMBER",
+  "version": "2.14.0-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.13.1
+sonar.projectVersion=2.14.0
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/fixtures/appforms/fixture_data_sources.js
+++ b/test/fixtures/appforms/fixture_data_sources.js
@@ -26,7 +26,7 @@ module.exports = nock('https://apps.feedhenry.com')
   .times(2)
   .reply(404, {
     userDetail: "Data Source Not Found"
-  })
+  }, {'x-fh-request-id': "dsrequest1234"})
   .post('/api/v2/appforms/data_sources', _.omit(mockDs, "_id"))
   .reply(200, mockDSCreated)
   .put('/api/v2/appforms/data_sources/' + mockDs._id, requiredDSUpdate)

--- a/test/fixtures/appforms/fixture_env_forms.js
+++ b/test/fixtures/appforms/fixture_env_forms.js
@@ -7,6 +7,11 @@ var envReplies = {
       name: "Some Test Form"
     };
   },
+  error: {
+    userDetail: "Environment with ID wrongenvid not found.",
+    systemDetail: "Environment with ID wrongenvid not found.",
+    code: "FH-SUPERCORE-ERROR"
+  },
   list : function(){
     return [envReplies.crud()];
   },
@@ -53,4 +58,7 @@ module.exports = nock('https://apps.feedhenry.com')
   .delete('/api/v2/mbaas/someenv/appforms/forms/someformid', '*')
   .reply(200, envReplies.crud)
   .get('/api/v2/mbaas/appforms/lifecycle', '*')
-  .reply(200, envReplies.lifecycle);
+  .reply(200, envReplies.lifecycle)
+  //An error condition with a request id header
+  .post('/api/v2/mbaas/wrongenvid/appforms/forms/someformid/deploy', '*')
+  .reply(500, envReplies.error, {'x-fh-request-id': "requestid12345"});

--- a/test/unit/fh3/appforms/data_sources/test_data_sources.js
+++ b/test/unit/fh3/appforms/data_sources/test_data_sources.js
@@ -35,7 +35,9 @@ module.exports = {
   },
   "test read data source not found": function(done){
     appformsDataSources.read({id: "wrongdsid"}, function(err, data){
-      assert.ok(err.indexOf("Found") > -1, "Expected Not Found Error Message");
+      assert.ok(err.toString().indexOf("Found") > -1, "Expected Not Found Error Message");
+      //An error response should have a request ID (See test/fixtures/appforms/fixture_data_sources)
+      assert.equal('dsrequest1234', err.requestId);
       assert.ok(!data, "Expected No Data");
       done();
     });

--- a/test/unit/fh3/appforms/test_env_forms.js
+++ b/test/unit/fh3/appforms/test_env_forms.js
@@ -43,6 +43,15 @@ module.exports = {
       return cb();
     });
   },
+  'test appforms-forms deploy wrong environment': function(cb) {
+    appformsenvforms.deploy({ id: 'someformid', environment: "wrongenvid" }, function (err){
+      assert.ok(err, "Expected an error");
+      //An error should produce a request ID (see fixture_env_forms.js)
+      assert.equal('requestid12345', err.requestId);
+      assert.ok(err.toString().indexOf('Environment with ID wrongenvid not found') > -1, "Expected an environment error message");
+      return cb();
+    });
+  },
   'test appforms-forms undeploy': function(cb) {
     appformsenvforms.undeploy({ environment: "someenv", id : 'someformid' }, function (err){
       assert.equal(err, null);


### PR DESCRIPTION
# Motivation

When a user gets an error back from the platform, it would be useful to display the Request ID associated with the error. 

This will help with debugging.

# Changes

- The error printed to the console in cli-mode will include the request ID
- The error returned when used as a module will return a request ID as part of the error.