### PR TITLE
Rhmap 10014 add request logs search command

### DIFF
--- a/lib/cmd/fh3/admin/logs/syslogs.js
+++ b/lib/cmd/fh3/admin/logs/syslogs.js
@@ -1,0 +1,77 @@
+/* globals i18n */
+var common = require('../../../../common.js');
+var _ = require('underscore');
+
+module.exports = {
+  'desc': i18n._('Search for log entries associated with a request ID. This requires aggregated logging to be enabled.'),
+  'examples': [{
+    cmd: 'fhc admin syslogs --requestId="07401646-b55e-4b9f-a181-c42f2fcbfd17" --projects="core,mbaas"',
+    desc: i18n._('Searching for log entries associated with request ID: 07401646-b55e-4b9f-a181-c42f2fcbfd17')
+  }],
+  'demand': ['requestId', 'projects'],
+  'describe': {
+    'requestId': i18n._("A request ID to search for."),
+    'projects': i18n._("A comma-separated list of project names to search for logs in."),
+    'numLogEntries': i18n._("The maximum number of log entries returned. Default is 1000."),
+    'orderBy': i18n._("The order of entries, by timestamp, to be displayed. The available options are 'first' or 'last'")
+  },
+  'orderingParams': {
+    'first': 'asc',
+    'last': 'desc'
+  },
+  'perm': 'cluster/reseller:read',
+  'url': "/api/v2/logs/syslogs",
+  'method': 'post',
+  'preCmd': function (params, cb) {
+    var projects = params.projects.split(',');
+    params.orderBy = params.orderBy || "first";
+    params.order = this.orderingParams[params.orderBy];
+
+
+    if(!params.order) {
+      return cb(new Error(i18n._("orderBy can either be 'first' or 'last'")));
+    }
+
+    //Creating indexes from the project names.
+    //See https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference-1-5.html#api-search-1-5
+    projects = _.map(projects, function (projectName) {
+      return projectName + ".*";
+    });
+
+    projects = projects.join(',');
+
+    //Creating a search query for elasticsearch
+    var searchParams = {
+      index: projects,
+      size: params.numLogEntries || 1000,
+      body: {
+        query: {
+          filtered: {
+            query: {
+              match: {
+                reqId: {
+                  query: params.requestId,
+                  //The query should match all parts of the request ID
+                  operator: 'and'
+                }
+              }
+            }
+          }
+        },
+        //Most recent first.
+        sort: {
+          "time": {
+            "order": params.order
+          }
+        }
+      }
+    };
+
+    return cb(null, searchParams);
+  },
+  'postCmd': function(searchResults, cb) {
+    searchResults._table = common.createTableForSyslogs(searchResults);
+
+    return cb(null, searchResults);
+  }
+};

--- a/lib/cmd/fhc/login.js
+++ b/lib/cmd/fhc/login.js
@@ -49,8 +49,8 @@ function login(argv, cb) {
     }, [], function(pw) {
       u.p = pw;
     })(function(cb) {
-      fhlogin(u.u, u.p, function(err, json) {
-        processLogin(u.u, u.p, err, json, cb);
+      fhlogin(u.u, u.p, function(err, json, response) {
+        processLogin(u.u, u.p, err, json, response, cb);
       });
     })();
   } else if (args.length === 1) {
@@ -62,16 +62,16 @@ function login(argv, cb) {
     }, [], function(pw) {
       u.p = pw;
     })(function(cb) {
-      fhlogin(args[0], u.p, function(err, json) {
-        processLogin(args[0], u.p, err, json, cb);
+      fhlogin(args[0], u.p, function(err, json, response) {
+        processLogin(args[0], u.p, err, json, response, cb);
       });
     })();
   } else if (args.length < 2) {
     return cb(i18n._("Please specify username and password."));
   } else {
     var domain = args[2];
-    fhlogin(args[0], args[1], domain, function(err, json) {
-      processLogin(args[0], args[1], err, json, cb);
+    fhlogin(args[0], args[1], domain, function(err, json, response) {
+      processLogin(args[0], args[1], err, json, response, cb);
     });
   }
 }
@@ -102,8 +102,10 @@ function signOver(signoverUrl, cb) {
 }
 
 // Process our login result, save target, etc
-function processLogin(user, pwd, err, json, cb) {
+function processLogin(user, pwd, err, json, httpResponse, cb) {
   if (err) {
+    err = _.isString(err) ? new Error(err) : err;
+    err = fhreq.createErrorMessage(err, httpResponse);
     return cb(err);
   }
   var js = JSON.parse(json);
@@ -132,8 +134,9 @@ function processLogin(user, pwd, err, json, cb) {
     cb(i18n._("Multiple domains not supported for signover yet - please target the specific domain you want to login to"));
   } else {
     if (js.result !== 'ok') {
-      login.message = i18n._("Login failed: ") + js.reason;
-      return cb(i18n._("login failed: ") + js.reason, js);
+      login.message = fhreq.createErrorMessage(new Error(i18n._("login failed: ") + js.reason), httpResponse);
+      err = login.message;
+      return cb(err, js);
     } else {
       saveLogin(user, js.login, js.domain, null, function(err) {
         cb(err, js);

--- a/lib/common.js
+++ b/lib/common.js
@@ -205,6 +205,29 @@ exports.style = function () {
   return ret;
 };
 
+/**
+ * Creating a table to view log results (See https://www.elastic.co/guide/en/elasticsearch/reference/1.5/_the_search_api.html)
+ * @param logSearchResults
+ */
+exports.createTableForSyslogs = function(logSearchResults) {
+  var table = new Table({
+    head: ['Time', 'Message', 'Level'],
+    style: exports.style()
+  });
+
+  _.each((logSearchResults.hits || {}).hits || [], function (logEntry) {
+    var messages = _.pick(logEntry._source, 'msg', 'error', 'err', 'message');
+
+    messages = _.map(_.compact(messages), function(message){
+      return message.replace(/\r?\n|\r/g,'');
+    });
+
+    table.push([logEntry._source.time, messages.join(' '), logEntry._source.level]);
+  }, this);
+
+  return table;
+};
+
 // put our apps into table format..
 exports.createTableForApps = function (apps) {
   // calculate widths

--- a/lib/utils/fhlogin.js
+++ b/lib/utils/fhlogin.js
@@ -59,7 +59,7 @@ function login(username, password, domain, cb) {
 function done(cb) {
   return function (error, data, json, response) {
     if (!error && (!response || response.statusCode === 200)) {
-      return cb(error, json);
+      return cb(error, json, response);
     }
     log.silly(response, "login response");
     log.error(JSON.stringify(data), "login");

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.14.0-BUILD-NUMBER",
+  "version": "2.15.0-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.14.0-BUILD-NUMBER",
+  "version": "2.15.0-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.14.0
+sonar.projectVersion=2.15.0
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/fixtures/admin/fixture_logs.js
+++ b/test/fixtures/admin/fixture_logs.js
@@ -1,0 +1,82 @@
+var nock = require('nock');
+var data = require('./environments');
+
+var searchParams = {
+  "index": "core.*,mbaas.*",
+  "size": 1000,
+  "body": {
+    "query": {
+      "filtered": {
+        "query": {
+          "match": {
+            "reqId": {
+              "query": "somerequestidtosearch",
+              "operator": "and"
+            }
+          }
+        }
+      }
+    },
+    "sort": {
+      "time": {
+        "order": "asc"
+      }
+    }
+  }
+};
+
+//Mock response from the logs API
+var searchResponse = {
+  "took": 16,
+  "timed_out": false,
+  "_shards": {
+    "total": 40,
+    "successful": 40,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "core.a9a3c15a-701d-11e6-9edd-fa163e2365b6.2016.09.06",
+        "_type": "fluentd",
+        "_id": "AVb-3WpRlS9yXTAEKeAK",
+        "_score": null,
+        "_source": {
+          "time": "2016-09-06T09:38:57.317Z",
+          "name": "supercore",
+          "hostname": "172.16.72.225",
+          "pid": 1,
+          "reqId": "somerequestidtosearch",
+          "level": 50,
+          "err": "Error reading environment 'doesnotexist\"",
+          "req_method": "GET",
+          "req_url": "/doesnotexist/appforms/forms",
+          "req_worker": -1,
+          "msg": "MbaaS Error",
+          "v": 0,
+          "docker_container_id": "a62cef5c5d21057fa6d48d313cca201c9a5a540ab7028677a039fa45a900ec58",
+          "kubernetes_namespace_name": "core",
+          "kubernetes_pod_id": "328fb2be-7388-11e6-9edd-fa163e2365b6",
+          "kubernetes_pod_name": "fh-supercore-4-zql1d",
+          "kubernetes_container_name": "fh-supercore",
+          "kubernetes_labels_deployment": "fh-supercore-4",
+          "kubernetes_labels_deploymentconfig": "fh-supercore",
+          "kubernetes_labels_name": "fh-supercore",
+          "kubernetes_host": "172.16.72.225",
+          "kubernetes_namespace_id": "a9a3c15a-701d-11e6-9edd-fa163e2365b6",
+          "message": null,
+          "version": "1.2.0"
+        },
+        "sort": [
+          1473154737317
+        ]
+      }
+    ]
+  }
+};
+
+
+module.exports = nock('https://apps.feedhenry.com')
+  .post('/api/v2/logs/syslogs', searchParams).reply(200, searchResponse);

--- a/test/unit/fh3/admin/logs/test_syslogs.js
+++ b/test/unit/fh3/admin/logs/test_syslogs.js
@@ -1,0 +1,30 @@
+var assert = require('assert');
+var genericCommand = require('genericCommand');
+require('test/fixtures/admin/fixture_logs');
+var adminLogs = {
+  syslogs: genericCommand(require('cmd/fh3/admin/logs/syslogs'))
+};
+
+
+module.exports = {
+  'test search for logs': function(done) {
+    var mockRequestId = "somerequestidtosearch";
+    adminLogs.syslogs({
+      requestId: mockRequestId,
+      projects: "core,mbaas"
+    }, function(err, searchResponse){
+      assert.ok(!err, "Expected no error " + err);
+
+      //The search response should be JSON
+      assert.ok(searchResponse, "Expected a search response");
+
+      assert.equal(mockRequestId, searchResponse.hits.hits[0]._source.reqId);
+
+      //There should be a table.
+      assert.ok(searchResponse._table, "Expected a table for the search response");
+
+      assert.ok(searchResponse._table.toString().indexOf('Error reading environment') > -1);
+      done();
+    });
+  }
+};


### PR DESCRIPTION
# Motivation 

This command allows users to search for logs based on a request ID. This will also be very useful for fh-uart for collecting logs for failing requests.

# Changes

- Added a new command `fhc admin logs syslogs` to allow users to search for logs.