### PR TITLE
RHMAP-10713 - fhc environment update improvement

### DIFF
--- a/lib/utils/mbaas-token-check.js
+++ b/lib/utils/mbaas-token-check.js
@@ -9,9 +9,7 @@ function checkMbaasType(request, cb) {
       return cb(err);
     }
 
-    if (response.type === 'openshift3') {
-      request.targetType = 'openshift3';
-    }
+    request.targetType = response.type;
 
     // Ensure that a token is provided if creating an openshift3 environment
     if (response.type === 'openshift3' && typeof request.token === 'undefined') {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.15.4-BUILD-NUMBER",
+  "version": "2.15.5-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"


### PR DESCRIPTION
# Motivation 

To keep our api consistent we should always sent the same format of data. In current implementation we were missing `targetType` field when type was different than openshift3. 