### PR TITLE
Fixing typos in the 'build' command snippet

### DIFF
--- a/lib/cmd/common/build.js
+++ b/lib/cmd/common/build.js
@@ -15,7 +15,7 @@ build.usage = "\nfhc build app=<app-id> destination=<destination> version=<versi
   + i18n._("\n'provisioning' is only optional for iphone or ipad builds");
 
 
-build.usage_ngui = "\nfhc build project=<project-id> app=<app-id> cloud_app=<cloud-app-id> tag=<tag> environment=<environment> destination=<destination> version=<version> config=<config> keypass=<private-key-password> certpass=<certificate-password> download=<true|false> bundleId=<credential bundle id> cordova_version=<cordova version>  branch=<branch name> commit=<commit hash>"
+build.usage_ngui = "\nfhc build project=<project-id> app=<app-id> cloud_app=<cloud-app-id> tag=<tag> environment=<environment> destination=<destination> version=<version> config=<config> keypass=<private-key-password> certpass=<certificate-password> download=<true|false> bundleId=<credential bundle id> cordova_version=<cordova version>  git-tag=<tag name> git-branch=<branch name> git-commit=<commit hash>"
   + i18n._("\nwhere <tag name> is the name of a connection tag for the cloud app, must be in Semantic Version format, e.g. 0.0.1.")
   + i18n._("\nwhere <environment id> is the id of a target environment, e.g. dev")
   + i18n._("\nwhere <destination> is one of: android, iphone, ipad, ios(for universal binary), blackberry, windowsphone7, windowsphone (windows phone 8)")
@@ -23,6 +23,7 @@ build.usage_ngui = "\nfhc build project=<project-id> app=<app-id> cloud_app=<clo
   + i18n._("\nwhere <config> is either 'debug' (default), 'distribution', or 'release'")
   + i18n._("\nwhere <bundleId> is the unique bundle identifier of the credential bundle. You can get it using 'fhc credentials list'. Required for all iOS builds.")
   + i18n._("\nwhere <cordova_version> is for specifying which version of Cordova to use. Currently supported: either 2.2 or 3.3. Only valid for Android for now.")
+    + i18n._("\nwhere <tag name> is the name of a tag to be built.")
   + i18n._("\nwhere <branch name> is the name of the git branch to build, defaults to 'master'")
   + i18n._("\nwhere <commit hash> is the full hash of the commit to build, if not the head of the branch. Must be used with <branch name>")
   + i18n._("\n'keypass' only needed for 'release' builds");


### PR DESCRIPTION
in the 'build' command snippet for build.usage.ngui, some of the params were incorrectly named
'branch' should be 'git-branch',  'commit' should be 'git-commit', and 'git-tag' was omitted.