### PR TITLE
Ping Millicore for target health check

### DIFF
--- a/lib/cmd/fhc/target.js
+++ b/lib/cmd/fhc/target.js
@@ -47,7 +47,7 @@ function target (argv, cb) {
           return cb(err);
         }
         if(data.statusCode !== 200) {
-          return cb(i18n._("Invalid target: ") +tar);
+          return cb(i18n._("Invalid target: ") + tar + JSON.stringify(data));
         }
 
         return cb();
@@ -137,7 +137,7 @@ function undefinedTargCleanup(cb, tar) {
 }
 
 function pingTarget(targ, callback) {
-  fhreq.GET(targ, "/box/srv/1.1/act/sys/auth/logout", i18n._("error pinging target"), function(err, parsed, _, response) {
+  fhreq.GET(targ, "/box/srv/1.1/tst/version", i18n._("error pinging target"), function(err, parsed, _, response) {
     if(err) {
       return callback(err);
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.16.1-BUILD-NUMBER",
+  "version": "2.16.2-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.16.1
+sonar.projectVersion=2.16.2
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
For some odd reason, we call `/box/srv/1.1/act/sys/auth/logout` to check Millicore is alive during an `fhc target`.

This change calls the the `/box/srv/1.1/tst/version` EP instead for liveness.