### PR TITLE
RHMAP-11075 add User-Agent header

### DIFF
--- a/lib/cmd/fh3/app/_baseCloudRequest.js
+++ b/lib/cmd/fh3/app/_baseCloudRequest.js
@@ -6,6 +6,8 @@ var util = require('util');
 var fhc = require("../../../fhc");
 var request = require('request').defaults({'proxy': fhc.config.get("proxy")});
 var url = require('url');
+var os = require('os');
+
 module.exports = function(requestType){
   return {
     'demand' : ['app', 'data', 'env'],
@@ -52,7 +54,8 @@ module.exports = function(requestType){
     },
     'customCmd' : function(params, cb){
       var headers = {
-          "X-FH-AUTH-APP": this.key
+          "X-FH-AUTH-APP": this.key,
+          "User-Agent": "FHC/" + fhc._version + ' ' + os.platform() + '/' + os.release()
         },
         data = params.data;
 

--- a/lib/cmd/fhc/target.js
+++ b/lib/cmd/fhc/target.js
@@ -12,7 +12,7 @@ var ini = require("../../utils/ini");
 var login = require("./login.js");
 var targets = require("./targets.js");
 var log = require("../../utils/log");
-var request = require('request').defaults( {'proxy': fhc.config.get("proxy")});
+var fhreq = require("../../utils/request");
 var keys = require('../common/keys/user.js');
 var ngui = require("../common/ngui");
 var version = require("../common/version.js");
@@ -42,7 +42,7 @@ function target (argv, cb) {
   async.series([
     function(cb){
       // Valiate FeedHenry target can be pinged..
-      pingTarget([tar], function(err, data){
+      pingTarget(tar, function(err, data){
         if(err) {
           return cb(err);
         }
@@ -137,11 +137,12 @@ function undefinedTargCleanup(cb, tar) {
 }
 
 function pingTarget(targ, callback) {
-  request(targ + "/box/srv/1.1/act/sys/auth/logout", function(err, response, body){
+  fhreq.GET(targ, "/box/srv/1.1/act/sys/auth/logout", i18n._("error pinging target"), function(err, parsed, _, response) {
     if(err) {
       return callback(err);
     }
-    return callback(err, {statusCode: response.statusCode, data: body});
+
+    return callback(err, {statusCode: response.statusCode, data: parsed});
   });
 }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.15.6-BUILD-NUMBER",
+  "version": "2.16.1-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.16.0-BUILD-NUMBER",
+  "version": "2.16.1-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.16.0
+sonar.projectVersion=2.16.1
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
# Motivation

Some of the older commands in FHC where using the `request` library directly (and not through `fhreq`) and they were not sendind the `User-Agent` header when calling millicore. The `User-Agent` must be set to `FHC`, in order to skip the CSRF check.

ping @wei-lee @pmdarrow @laurafitzgerald @JameelB 