### PR TITLE
FH 2850 - Team assignment on creation of user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [Unreleased]
+* FH-2850 - Allow team assignment when creating a user with fhc
+
 # 2.6.0 - 2016-03-11 -  Niall Donnelly
 
 * RHMAP-1722 - Data Sources APIs

--- a/doc/common/admin-users.md
+++ b/doc/common/admin-users.md
@@ -4,10 +4,10 @@ fhc-admin-users(1) -- Administer FeedHenry Users
 ## SYNOPSIS
 
     fhc admin-users list
-    fhc admin-users create username=<username> [password=<password>] [email=<email>] [name=<name>] [roles=<roles>] [authpolicies=<authpolicies>] [invite=<invitation>]
+    fhc admin-users create username=<username> [password=<password>] [email=<email>] [name=<name>] [roles=<roles>] [authpolicies=<authpolicies>] [invite=<invitation>] [teams=<teamIds>]
     fhc admin-users delete <username>
     fhc admin-users read <username>
-    fhc admin-users update username=<username> [password=<password>] [email=<email>] [name=<name>] [roles=<roles>] [authpolicies=<authpolicies>] [inviation=<invitation>] [enabled=<enabled>]
+    fhc admin-users update username=<username> [password=<password>] [email=<email>] [name=<name>] [roles=<roles>] [authpolicies=<authpolicies>] [inviation=<invitation>] [teams=<teamIds>] [enabled=<enabled>]
     fhc admin-users enable <username>
     fhc admin-users disable <username>
     fhc admin-users changeroles <username> <roles>
@@ -20,3 +20,7 @@ fhc-admin-users(1) -- Administer FeedHenry Users
 ## DESCRIPTION
 
 This command allows you to Administer Users on the FeedHenry Platform. For more information, see http://docs.feedhenry.com/v2/useradmin.html.
+
+## Examples
+
+    fhc admin-users create username=testuser email=testuser@test.com teams=5783b4d706bb371b0960eff9,5783b21b0fd0211e09f218e9

--- a/lib/cmd/common/admin-users.js
+++ b/lib/cmd/common/admin-users.js
@@ -10,10 +10,10 @@ users.import = importUsers;
 
 users.desc = i18n._("Administer FeedHenry Users");
 users.usage = "\nfhc admin-users list"
-             +"\nfhc admin-users create username=<username> [password=<password>] [email=<email>] [name=<name>] [roles=<roles>] [authpolicies=<authpolicies>] [invite=<invitation>] [storeItemGroups=<groups>]"
+             +"\nfhc admin-users create username=<username> [password=<password>] [email=<email>] [name=<name>] [roles=<roles>] [authpolicies=<authpolicies>] [invite=<invitation>] [teams=<teamIds>] [storeItemGroups=<groups>]"
              +"\nfhc admin-users delete <username>"
              +"\nfhc admin-users read <username>"
-             +"\nfhc admin-users update username=<username> [password=<password>] [email=<email>] [name=<name>] [roles=<roles>] [authpolicies=<authpolicies>] [inviation=<invitation>] [enabled=<enabled>] [storeItemGroups=<groups>]"
+             +"\nfhc admin-users update username=<username> [password=<password>] [email=<email>] [name=<name>] [roles=<roles>] [authpolicies=<authpolicies>] [inviation=<invitation>] [enabled=<enabled>] [teams=<teamIds>] [storeItemGroups=<groups>]"
              +"\nfhc admin-users enable <username>"
              +"\nfhc admin-users disable <username>"
              +"\nfhc admin-users changeroles <username> <roles>"
@@ -215,7 +215,7 @@ function parseVal(name, val){
   if(val === "false"){
     return false;
   }
-  if(name === "storeItemGroups") {
+  if(name === "storeItemGroups" || name === "teams") {
     var tmp = [];
     val.split(/,/).forEach(function(v){
       if(v.trim() !== "") {


### PR DESCRIPTION
**JIRA:** https://issues.jboss.org/browse/FH-2850

This will allow a comma separated list of team ids when creating a new user e.g. `fhc admin-users create username=testuser email=testuser@test.com teams=5783b4d706bb371b0960eff9,5783b21b0fd0211e09f218e9`

@david-martin A have a concern, is there any more documentation that needs to be modified for users to be aware of how to use this change.