### PR TITLE
FH-2853 - Change publish label to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "fhc": "./bin/fhc.js"
   },
   "publishConfig": {
-    "tag": "latest-2"
+    "tag": "latest"
   },
   "dependencies": {
     "async": "0.2.9",


### PR DESCRIPTION
## Motivation 

Use latest by default when publishing package. 
Latest tag is used by default, but I wanted to leave it for informational purposes.

