### PR TITLE
Change npm tag in version command

### DIFF
--- a/lib/cmd/common/version.js
+++ b/lib/cmd/common/version.js
@@ -90,7 +90,7 @@ module.exports = {
     var proxyRequest = request.defaults({'proxy': fhc.config.get("proxy"), timeout: timeout});
     proxyRequest.get({
       json: true,
-      url: 'http://registry.npmjs.org/fh-fhc/latest-2'
+      url: 'http://registry.npmjs.org/fh-fhc/latest'
     }, function (err, response, body) {
       if (err || !body || !body.version) {
         self.errorChecking = true;


### PR DESCRIPTION
## Motivation

Change version tag from latest-2 to latest as we no longer support latest-2. 
Without that change fh-fhc would always show that the latest version is outdated. 
Suggestion is to merge this and release it with some other changes.