### PR TITLE
Fix of assert in test_environment.js file

### DIFF
--- a/test/unit/fh3/admin/test_environments.js
+++ b/test/unit/fh3/admin/test_environments.js
@@ -38,7 +38,7 @@ module.exports = {
     adminenvironments.create({ label: 'lbl1', target: 'testTarget1', id: '1a' }, function(err, data) {
       assert.equal(err, null);
 
-      assert.equal(data.target.id, 'testTarget1');
+      assert.equal(data.target, 'testTarget1');
       assert.equal(data.label, 'lbl1');
       assert.equal(data.id, '1a');
       return cb();


### PR DESCRIPTION
Motivation: I tried to run `grunt test` but I was getting error:

Uncaught exception:  'AssertionError: undefined == 'testTarget1'

After this change it has gone.
