### PR TITLE
RHMAP 12418: Fix cloud app import from existing git repo

### DIFF
--- a/lib/cmd/common/import.js
+++ b/lib/cmd/common/import.js
@@ -116,12 +116,16 @@ function importAppNgui(projectId, appTitle, appTemplateType, fileOrRepo, deployE
 
   // Git import is a straight POST, no form related upload
   function importGitRepo() {
-    var repo = fileOrRepo;
+
+    // slice off the '.git' suffix
+    var repo = fileOrRepo.slice(0, -4);
     var payload = {
       title: appTitle,
       connections:[],
       template: {
         repoUrl: repo,
+        repoBranch: 'refs/heads/master',
+        imported: true,
         type: appTemplateType
       }
     };


### PR DESCRIPTION
To test this run:

fhc import <some-project-id> rhmap-12418-fix-cloud-app cloud_nodejs https://github.com/feedhenry/testing-cloud-app.git

Check in Editor that the files are really there.