### PR TITLE
🐛 Fix inline help for clusterprops command

### DIFF
--- a/lib/cmd/common/clusterprops.js
+++ b/lib/cmd/common/clusterprops.js
@@ -2,12 +2,12 @@
 module.exports = clusterprops;
 
 clusterprops.desc = i18n._("Manage clusterprops");
-clusterprops.usage = " fhc admin clusterprops list \n fhc admin clusterprops read <name> \n fhc admin clusterprops update <prop> <value> \n " +
-  "fhc admin clusterprops create <prop> <value> \n fhc admin clusterprops delete <prop> ";
-clusterprops.updateUsage = "fhc admin clusterprops update <prop> <value>";
-clusterprops.createUsage = "fhc admin clusterprops create <prop> <value>";
-clusterprops.deleteUsage = "fhc admin clusterprops del <prop>";
-clusterprops.listUsage = "fhc admin clusterprops";
+clusterprops.usage = " fhc clusterprops list \n fhc clusterprops read <name> \n fhc clusterprops update <prop> <value> \n " +
+  "fhc clusterprops create <prop> <value> \n fhc clusterprops delete <prop> ";
+clusterprops.updateUsage = "fhc clusterprops update <prop> <value>";
+clusterprops.createUsage = "fhc clusterprops create <prop> <value>";
+clusterprops.deleteUsage = "fhc clusterprops del <prop>";
+clusterprops.listUsage = "fhc clusterprops";
 clusterprops.perm = "cluster:read";
 
 var common = require("../../common");


### PR DESCRIPTION
Running `fhc clusterprops` by itself will display the following output, indicating that it's a subcommand of the `admin` command:

```
$ fhc clusterprops
fhc ERR! Invalid action: undefined
fhc ERR! Usage:
fhc ERR!  fhc admin clusterprops list
fhc ERR!  fhc admin clusterprops read <name>
fhc ERR!  fhc admin clusterprops update <prop> <value>
fhc ERR!  fhc admin clusterprops create <prop> <value>
fhc ERR!  fhc admin clusterprops delete <prop>
fhc Command executed with error
```

Then trying to use it as a subcommand of the `admin` command will fail as follows:

```
$ fhc admin clusterprops list
fhc ERR! Error: Command not found: clusterprops
fhc ERR!
fhc ERR! System Linux 4.8.14-300.fc25.x86_64
fhc ERR! command "/home/grdryn/.nvm/versions/node/v4.6.0/bin/node" "/home/grdryn/.nvm/versions/node/v4.6.0/bin/fhc" "admin" "clusterprops" "list"
fhc Command executed with error
```

This change just fixes the text to be match reality. There's no version bump here, because I think it's fine for this change to just be merged and included in the next release, rather than having a release of its own.