### PR TITLE
FH 2993 filter projects by user

### DIFF
--- a/lib/cmd/fh3/projects.js
+++ b/lib/cmd/fh3/projects.js
@@ -2,7 +2,7 @@
 module.exports = projects;
 
 projects.desc = i18n._("Manage projects");
-projects.usage = "fhc projects [list]" +
+projects.usage = "fhc projects [list] [<author-email>]" +
     "\nfhc projects create <project-title> [<template-id>] --env=<environment>" +
     "\nfhc projects update <project-id> <prop-name> <value>" +
     "\nfhc projects read <project-id>" +
@@ -52,6 +52,10 @@ function projects(argv, cb) {
 function listProjects(args, cb) {
   common.listProjects(function (err, projs) {
     if (err) return cb(err);
+    //Allow filtering by author email
+    if(args[1]){
+      projs = _.where(projs, {authorEmail: args[1]});
+    }
     if (ini.get('table') === true) {
       projects.table = common.createTableForProjects(projs);
     }


### PR DESCRIPTION
Motivation - https://issues.jboss.org/browse/FH-2993

Usage changes from `fhc projects list` to `fhc projects [list] [<author-email>]`

**Example**: `fhc projects list amoran@redhat.com`. 
This will only return all the projects where the `authorEmail` is `amoran@redhat.com`