### PR TITLE
Fh 2884 remove undefined login error

### DIFF
--- a/lib/cmd/fhc/login.js
+++ b/lib/cmd/fhc/login.js
@@ -134,7 +134,7 @@ function processLogin(user, pwd, err, json, httpResponse, cb) {
     cb(i18n._("Multiple domains not supported for signover yet - please target the specific domain you want to login to"));
   } else {
     if (js.result !== 'ok') {
-      login.message = fhreq.createErrorMessage(new Error(i18n._("login failed: ") + js.reason), httpResponse);
+      login.message = fhreq.createErrorMessage(new Error(i18n._("There was an error with your Username/Password combination. Please try again.")), httpResponse);
       err = login.message;
       return cb(err, js);
     } else {


### PR DESCRIPTION
Motivation - https://issues.jboss.org/browse/FH-2884

Updated the login error with some useful text.

**Before**
```
fhc ERR! Error: login failed: undefined
fhc ERR! Request ID:  3f17adaa-eb4d-481a-9a54-4b1a25f398db
fhc ERR!
fhc ERR! System Darwin 16.0.0
fhc ERR! command "/Users/amoran/.nvm/versions/node/v4.4.3/bin/node" "/Users/amoran/.nvm/versions/node/v4.4.3/bin/fhc" "login"
fhc Command executed with error
```
**After**
```
fhc ERR! Error: There was an error with your Username/Password combination. Please try again.
fhc ERR! Request ID:  091d59fa-f4d7-49f4-9635-df4110f71b06
fhc ERR!
fhc ERR! System Darwin 16.0.0
fhc ERR! command "/Users/amoran/.nvm/versions/node/v4.4.3/bin/node" "/Users/amoran/Work/fh-fhc/bin/fhc.js" "login"
fhc Command executed with error
```