### PR TITLE
Rhmap 12418 cloud app import not working

### DIFF
--- a/lib/cmd/common/import.js
+++ b/lib/cmd/common/import.js
@@ -4,7 +4,7 @@ module.exports = imports;
 
 imports.desc = i18n._("Import a previously exported FeedHenry zipfile");
 imports.usage = "\nfhc import <feedhenry zip file>";
-imports.usage_ngui = "\nfhc import <project-id> <app-title> <app-template-type> [<zip-file> || <git-repo>] --env=environment"
+imports.usage_ngui = "\nfhc import <project-id> <app-title> <app-template-type> [<zip-file> || <git-repo>] [<git-branch>] --env=environment"
   + i18n._("\nNote: If --env is provided and the app is deployed, it will be deployed to the specified environment automatically. Set it to 'none' if it should not be deployed to anywhere.")
   + i18n._("\nNote: if no file or repo is specified, a bare git repo is created");
 
@@ -32,8 +32,10 @@ function imports (argv, cb) {
     var appTitle = args[1];
     var appTemplateType = args[2];
     var fileOrRepo = args[3];  // note this is optional, can be null
+    // note this is optional, will default to master
+    var repoBranch = args[4] || 'master';
     var deployEnv = ini.getEnvironment(argv, true);
-    return importAppNgui(projectId, appTitle, appTemplateType, fileOrRepo, deployEnv, cb);
+    return importAppNgui(projectId, appTitle, appTemplateType, fileOrRepo, repoBranch, deployEnv, cb);
   }else{
     if (args.length !== 1) return cb(imports.usage);
     var file = args[0];
@@ -64,7 +66,7 @@ function importApp(file, cb) {
   });
 }
 
-function importAppNgui(projectId, appTitle, appTemplateType, fileOrRepo, deployEnv, cb) {
+function importAppNgui(projectId, appTitle, appTemplateType, fileOrRepo, repoBranch, deployEnv, cb) {
 
   if (!fileOrRepo) return importBareRepo();
 
@@ -122,12 +124,21 @@ function importAppNgui(projectId, appTitle, appTemplateType, fileOrRepo, deployE
       connections:[],
       template: {
         repoUrl: repo,
-        type: appTemplateType
+        type: appTemplateType,
+        imported: true,
+        repoBranch: 'refs/heads/' + repoBranch
       }
     };
 
     var url = 'box/api/projects/' + projectId + '/apps';
-    common.doApiCall(fhreq.getFeedHenryUrl(), url, payload,  i18n._("Error importing git repo: "), cb);
+    common.doApiCall(fhreq.getFeedHenryUrl(), url, payload, i18n._("Error importing git repo: "), function(err, data) {
+      if (err) {
+        return cb(err);
+      }
+
+      log.silly('import response', data);
+      return cb(null, data);
+    });
   }
 
   // Import with bare git repo


### PR DESCRIPTION
**Motivation:** https://issues.jboss.org/browse/RHMAP-12418

- Updating request payload to add mandatory options. (`imported ` & `repoBranch `)
- Also updated working result to be more user-friendly. Previously it just returned a large json object.