### PR TITLE
FH-2996 Allowing type MBAAS for fhc admin-policies create

### DIFF
--- a/lib/cmd/common/admin-policies.js
+++ b/lib/cmd/common/admin-policies.js
@@ -14,11 +14,12 @@ policies.desc = i18n._("Operations on Auth Policies for connecting to 3rd party 
 policies.usage = "\nfhc policies list"
               +"\nfhc policies create <policy-id> <policy-type> <config> [<check-user-exists>] [<check-user-approved>]"
               +"\nfhc policies update <guid> <policy-id> <policy-type> <config> [<check-user-exists>] [<check-user-approved>]"
-              +i18n._("\n    where <policy-type> is one of: OAUTH1 | OAUTH2 | LDAP | OPENID | FEEDHENRY")
+              +i18n._("\n    where <policy-type> is one of: OAUTH1 | OAUTH2 | LDAP | OPENID | FEEDHENRY | MBAAS")
               +i18n._('\n    where <config> is a json object corresponding to the policy type, e.g.')
               +i18n._('\n          for OAuth2: "{"clientId": "1234567890.apps.example.com",  "clientSecret": "Wfv8DQw80hhyaBqnW37x5R23", "provider": "GOOGLE"}"')
               +i18n._('\n          for LDAP: "{"authmethod": "simple", "url": "ldap://foo.example.com:389, "dn": "ou=people,dc=example,dc=com", "dn_prefix": "cn", "provider": "LDAP"}')
               +i18n._('\n                       authmethod can be one of: "simple", "DIGEST-MD5", "CRAM-MD5", or "GSSAPI"')
+              +i18n._('\n          for MBAAS: "{"provider":"MBAAS","mbaas":"mqijsw3tgpn6htwmbbg27jl6","authEndpoint":"/test","defaultEnvironment":"dev"}"')
               +i18n._("\n    where <check-user-exists> is one of: true | false. The default here is 'false'.")
               +i18n._("\n    where <check-user-approved> is one of: true | false. The default here is 'false'.")
               +"\nfhc policies delete <guid>"
@@ -37,7 +38,8 @@ var validPolicies = [
   'OAUTH2',
   'LDAP',
   'OPENID',
-  'FEEDHENRY'
+  'FEEDHENRY',
+  'MBAAS'
 ];
 
 function errorMessageString(action) {


### PR DESCRIPTION
**Motivation:** https://issues.jboss.org/browse/FH-2996

No changes to the payload or request. Allowing `MBAAS` to be a valid type and update usage with example