### PR TITLE
Rhmap 10385 admin policies update incorrect args length

### DIFF
--- a/lib/cmd/common/admin-policies.js
+++ b/lib/cmd/common/admin-policies.js
@@ -64,8 +64,8 @@ function policies (argv, cb) {
     if (args.length !== 2) return cb(errorMessageString(action) + policies.usage);
     return read(args[1], cb);
   } else if (action === 'update'){
-    if (args.length !== 6) return cb(errorMessageString(action) + policies.usage);
-    return update(args[1], args[2], args[3], args[4], args[5], cb);
+    if (args.length <= 4) return cb(errorMessageString(action) + policies.usage);
+    return update(args[1], args[2], args[3], args[4], args[5], args[6], cb);
   } else if (action === 'delete'){
     if (args.length !== 2) return cb(errorMessageString(action) + policies.usage);
     return deletePolicy(args[1], cb);


### PR DESCRIPTION
** Motivation:**https://issues.jboss.org/browse/RHMAP-10385

- Updated admin policies update args validation to only count mandatory args.
- Updated update function with the correct amount of args