### PR TITLE
Remove zanata changes 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -77,7 +77,6 @@ module.exports = function(grunt) {
 
   grunt.loadNpmTasks('grunt-fh-build');
   grunt.loadNpmTasks('grunt-jsxgettext');
-  grunt.loadNpmTasks('grunt-zanata-js');
 
   grunt.registerTask('test', ['fh:test']);
   grunt.registerTask('unit', ['jshint', 'fh:unit']);
@@ -85,7 +84,7 @@ module.exports = function(grunt) {
   grunt.registerTask('coverage', ['fh:coverage']);
   grunt.registerTask('analysis', ['fh:analysis']);
   grunt.registerTask('potupload', ['jsxgettext:pot', 'zanata:push']);
-  grunt.registerTask('dist', ['zanata:pull', 'fh:dist']);
+  grunt.registerTask('dist', ['fh:dist']);
   grunt.registerTask('default', ['fh:default']);
 
   grunt.registerTask('docs', ['docs-generate', 'docs-index', 'shell:fh-run-array:docsToDoxy']);


### PR DESCRIPTION
# Motivation

Zatana changes are breaking build, prevents numerous PR's from being merged. 
Removing them for now. 

@tagoh @jasonmadigan - Feel free to reopen ticket, provide better implementation for this. 
It looks like we aren't able to call zatana translation service and build is timing out. 

Reverting this PR:
https://github.com/feedhenry/fh-fhc/pull/217