### PR TITLE
Removed unused destination for fhc configuration

### DIFF
--- a/lib/cmd/common/configuration.js
+++ b/lib/cmd/common/configuration.js
@@ -6,7 +6,7 @@ configuration.list = list;
 var util = require('util');
 
 // TODO - would be nice to get the destinations from the FeedHenry API
-var destinations = ['studio', 'android', 'embed', 'iphone', 'ipad', 'blackberry', 'windowsphone7', 'nokiawrt'];
+var destinations = ['studio', 'android', 'embed', 'iphone', 'ipad', 'blackberry', 'windowsphone7'];
 configuration.desc = i18n._("Manage client app configuration properties");
 configuration.usage = "\nfhc configuration [list] <app-id>"
            + "\nfhc configuration [list] <app-id> <destination>"


### PR DESCRIPTION
This fixes listing of destinations for command `fhc configuration <app-id> all`

@david-martin Hi, got a minute for a review?