### PR TITLE
Removed deprecated destination from docs

### DIFF
--- a/doc/common/configuration.md
+++ b/doc/common/configuration.md
@@ -7,7 +7,7 @@ fhc configuration [list] <app-id>
 fhc configuration [list] <app-id> <destination>
 fhc configuration set <app-id> <destination> <key> <value>
 
-where destination can be one of: studio, android, embed, iphone, ipad, blackberry, windowsphone7, nokiawrt or 'all'
+where destination can be one of: studio, android, embed, iphone, ipad, blackberry, windowsphone7 or 'all'
     
 ## DESCRIPTION
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.17.1-BUILD-NUMBER",
+  "version": "2.17.2-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"


### PR DESCRIPTION
Verify with `fhc configuration <app-id> all`

Hey @david-martin, got another minute? :)
I forgot to version bump and docs update. Many thanks!