### PR TITLE
Like fh-ngui, only create appTemplates which are selected

### DIFF
--- a/lib/cmd/fh3/projects.js
+++ b/lib/cmd/fh3/projects.js
@@ -112,6 +112,14 @@ function createProject(args, deployEnvironment, cb) {
     });
   }
 
+  // Like NGUI, filter out appTemplates which are
+  // not 'selected' before calling create
+  function filterSelectedApps(template) {
+    var selectedTemplates = _.where(template.appTemplates, {selected: true});
+    template.appTemplates = selectedTemplates;
+    return template;
+  }
+
 
   // Hackity hack: fh-art requires a custom blank template (which has no apps)
   // to facilitate this we have a sneaky 3'rd param here where we pass the template object in directly
@@ -122,6 +130,9 @@ function createProject(args, deployEnvironment, cb) {
     templates({ _ : ['projects', templateId] }, function(err, template) {
       if (err) return cb(err);
       if (!template) return cb(i18n._('Template not found: ') + templateId);
+
+      // Update appTemplates, to filter out unselected apps
+      filterSelectedApps(template);
       doCall(template, pollCallback);
     });
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.17.2-BUILD-NUMBER",
+  "version": "2.17.3-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.17.1
+sonar.projectVersion=2.17.3
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
https://issues.jboss.org/browse/RHMAP-13185

`fh-ngui` filters `appTemplates` in project templates to only include templates which have `selected: true`. Implementing this same logic here to behave like NGUI in fh-fhc.