### PR TITLE
Adding a Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ coverage/
 *.o
 cov-*
 plato
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM nodesource/centos7:4.4.7
+
+ADD package.json package.json
+RUN npm install
+ADD . .
+
+ENTRYPOINT ["node", "bin/fhc.js"]

--- a/README.md
+++ b/README.md
@@ -70,7 +70,41 @@ To use FHC via docker, run commands like:
 
 `$ docker run -v $HOME:/root -it feedhenry/fhc target https://rhmap.cup.feedhenry.io`
 
-We mount `$HOME` into the the container to persist configuration in `~/.fhcrc` & `~/.fhctargets` on the host.
+We mount `$HOME` into the the container to persist configuration in `~/.fhcrc` & `~/.fhctargets` on the host. You may want to alias this `docker run` command to `fhc`, by adding an alias to your shell's config:
+
+```
+alias fhc='docker run -v $HOME:/root -it feedhenry/fhc'
+```
+
+Now you'll be able to run commands similar to:
+
+```
+fhc target https://rhmap.cup.feedhenry.io
+```
+
+#### Building & Releasing for Docker
+
+To build:
+
+`$ docker build -t feedhenry/fhc .`
+
+Get your Image ID via:
+
+`$ docker images | grep fhc`
+`feedhenry/fhc          latest              0618027d8d57        8 minutes ago       749 MB`
+
+Tag this as latest & the version in `package.json`:
+
+`$ docker tag 0618027d8d57 feedhenry/fhc:latest`
+`$ docker tag 0618027d8d57 feedhenry/fhc:2.17.3`
+
+Push your images (you may need to login):
+
+`$ docker push feedhenry/fhc`
+
+Finally, verify your push by visiting:
+
+[https://hub.docker.com/r/feedhenry/fhc/tags/](https://hub.docker.com/r/feedhenry/fhc/tags/)
 
 ## Extending
 Version 1.0 of `fh-fhc` updates the structure of commands:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Older fhc commands still pass arguments in an ordered array, as below. The envir
     fhc.app.logs({_ : ['projectId', 'appId'], env : 'dev' }, function(){
     });
 
+### From Docker
+
+To use FHC via docker, run commands like:
+
+`$ docker run -v $HOME:/root -it feedhenry/fhc target https://rhmap.cup.feedhenry.io`
+
+We mount `$HOME` into the the container to persist configuration in `~/.fhcrc` & `~/.fhctargets` on the host.
 
 ## Extending
 Version 1.0 of `fh-fhc` updates the structure of commands:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.17.3-BUILD-NUMBER",
+  "version": "2.17.4-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"


### PR DESCRIPTION
Adding a `Dockerfile` for FHC. This will simplify further the environment requirements for `fh-cup`.

Some commands for testing:

```
docker run -v $HOME:/root -it feedhenry/fhc target https://rhmap.cup.feedhenry.io
docker run -v $HOME:/root -it feedhenry/fhc login username password
docker run -v $HOME:/root -it feedhenry/fhc projects
```

