### PR TITLE
RHMAP-12347 - [FHC tool] - Message Error: Missing 'tag' parameter is …

### DIFF
--- a/lib/cmd/common/build.js
+++ b/lib/cmd/common/build.js
@@ -116,9 +116,6 @@ function validateArgsNgui(args) {
   if (!args.cloud_app) {
     throw new Error(i18n._("Missing 'cloud_app' parameter"));
   }
-  if (!args.tag) {
-    throw new Error(i18n._("Missing 'tag' parameter"));
-  }
   if (buildForIos(args) && !args.bundleId) {
     throw new Error(i18n._("Missing 'bundleId' parameter"));
   }


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RHMAP-12347

Following local test succeed without tag parameter. 
Target Instance: https://support.us.feedhenry.com/#projects

```
Camilas-MBP:fh-fhc cmacedo$ bin/fhc.js build project=c36rft6z5jfoxwsoksvilp5t app=c36rftychwefssjstcvdlueq cloud_app=c36rft2h5fcjioiusdl3x5f6 environment=qed1-mbaas2-dev destination=android config=Debug 
...................
Download URL: https://support.us.feedhenry.com/digman/android-v3/dist/73a11b77-85ff-436f-a38a-73478e89b3d8/android~4.0~9~WFMDemoMobileApp.apk?digger=diggers.sam1-farm2-linux2
```