### PR TITLE
RHMAP-8290-A number of FHC commands arguments don't support Aliases

### DIFF
--- a/lib/utils/args.js
+++ b/lib/utils/args.js
@@ -56,19 +56,48 @@ function _normaliseFlagsAndArs(argsIntoCommand, cmd){
   }
   var processArgs = _.clone(process.argv);
   _.each(cmd.alias, function(alias, key){
-    if (key.match(/[0-9]/)){
-      var position = parseInt(key, 10),
-        arg = argsIntoCommand[position];
-      var hasArgumentAtPosition = !isNaN(position) && typeof arg !== 'undefined' && !arg.match(/^--/);
-      if (hasArgumentAtPosition){
+    if (isPositionAlias(key)){
+      var position = parseInt(key, 10), arg = argsIntoCommand[position];
+      if (hasValidPositionArgument(position, arg)){
         var idx = processArgs.indexOf(arg);
         if (idx > -1){
           processArgs[idx] = '--' + alias + '=' + arg;
         }
       }
+    } else {
+      arg = takeArgOfStringAlias(argsIntoCommand, alias);
+      if (hasValidArgOfStringAlias(arg, key)){
+        var idx = processArgs.indexOf(arg);
+        if (idx > -1){
+          processArgs[idx] = '--' + key + '=' + arg.split("=")[1];
+        }
+      }
     }
   });
   return processArgs;
+}
+
+function hasValidArgOfStringAlias(arg, key) {
+  return typeof arg !== 'undefined' && !arg.startsWith("--" +key) && !arg.startsWith("-" +key) && !arg.startsWith(key);
+}
+
+function hasValidPositionArgument(position, arg) {
+  return !isNaN(position) && typeof arg !== 'undefined' && !arg.match(/^--/) && !arg.match(/=/);
+}
+
+function isPositionAlias(key) {
+  return key.match(/[0-9]/);
+}
+
+function takeArgOfStringAlias(argsIntoCommand, alias) {
+  var argCommandValueFound;
+  _.each(argsIntoCommand, function(argCommandValue){
+    if(argCommandValue.startsWith("--" + alias) || argCommandValue.startsWith("-" + alias) || argCommandValue.startsWith(alias)){
+      argCommandValueFound = argCommandValue;
+      return;
+    }
+  });
+  return argCommandValueFound;
 }
 
 /*


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RHMAP-8290
This is for FHC is able to work with the string alias which already has in the project. 

**Steps to verify**

1.Take a valid project and appId into RHMAP studio
2.Check the result of the command bin/fhc.js app read --project=projectID --app=appID
3.Now check it with the alias setup for this command as following.
    * bin/fhc.js app read --p=projectID --a=projectID
    * bin/fhc.js app read -p=projectID -a=appID
    * bin/fhc.js app read p=projectID a=appID
    * bin/fhc.js app read projectID appID
All commands with allias must has the same result.