### PR TITLE
RHMAP-7690-fhversion defaults to 2 in .fhcrc if not logged into studi…

### DIFF
--- a/lib/cmd/fhc/target.js
+++ b/lib/cmd/fhc/target.js
@@ -56,6 +56,7 @@ function target (argv, cb) {
     function (cb){
       //First, checking if the target platform version is greater than a minimum value.
       version.checkTargetVersion([tar], cb);
+      fhc.config.set("fhversion", 3);
     }
   ], function(err){
     if(err){


### PR DESCRIPTION
JIRA : https://issues.jboss.org/browse/RHMAP-7690

Before change. ( $ cat .fhcrc )

```
fhclatest = {"version":"2.17.1-516","is":true,"ts":1494352909139,"current":"2.17.1-516"}
showlevel = 2
feedhenry = https://support.us.feedhenry.com/#projectsCamilas-MacBook-Pro:~ cmac 

```

After change.   ( $ cat .fhcrc )

```
Camilas-MacBook-Pro:~ cmacedo$ cat .fhcrc
fhclatest = {"version":"2.17.1-516","is":true,"ts":1494353500410,"current":"2.17.5-BUILD-NUMBER"}
showlevel = 2
fhversion = 3
feedhenry = https://gpte.us.training.redhatmobile.comCamilas-MacBook-Pro:~ cmacedo$ 


```
