### PR TITLE
RHMAP-15481 - Re-deployment via fhc get stuck with incorrect runtime …

### DIFF
--- a/lib/cmd/fh3/app/stage.js
+++ b/lib/cmd/fh3/app/stage.js
@@ -1,60 +1,177 @@
 /* globals i18n */
-var base = require('./_baseCloudCommand.js')('stage'),
-  ini = require('../../../utils/ini'),
-  common = require('../../../common'),
-  async = require('async');
-base.desc = i18n._("Stages a cloud application.");
-base.url = function(argv) {
-  var domain = ini.get("domain", "user");
-  var url = '/api/v2/mbaas/' + domain + '/' + argv.env +'/apps/' + argv.app + '/deploy';
-  return url;
-};
-base.method = 'post';
-base.describe.runtime = i18n._("The Node.js runtime of your application, e.g. node06 or node08 or node010");
-base.describe.clean = i18n._("Do a full, clean stage. Cleans out all old application log files, removes cached node modules and does an 'npm install' from scratch");
-base.describe.autodeploy = i18n._("Deploy the app automatically when the app repo is updated");
-base.describe['gitRef.type'] = i18n._("Specifies if you'd like to deploy a 'branch' or 'tag'");
-base.describe['gitRef.hash'] = i18n._("The commit hash you'd like to deploy if gitRef.type is 'branch'. HEAD will use the latest code for that branch");
-base.describe['gitRef.value'] = i18n._("The name of the branch you'd like to deploy");
-base.alias.runtime = "r";
-base.alias.clean = "c";
-base.alias.autodeploy = "d";
+var ini = require('../../../utils/ini');
+var common = require('../../../common');
+var async = require('async');
+var fhc = require("../../../fhc");
 
-//Add custom example
-base.examples[0].cmd = 'fhc app stage --app=<appGuid> --env=<environmentName> (Defaults to branch:master)';
+module.exports = {
+  'desc' : i18n._('Stages a cloud application.'),
+  'examples' :
+  [{
+    cmd : 'fhc app stage --app=<cloud-app-id> --env=<environment>',
+    desc : i18n._("Deploy of cloud application <app-id> on <environment> (Defaults to branch:master)")
+  },{
+    cmd : 'fhc app stage --app=<cloud-app-id> --env=<environment> --runtime=<runtime> --clean=false --autodeploy=true',
+    desc : i18n._("Deploy of cloud application <cloud-app-id> on <environment> with the <runtime> without Clean Stage option selected and 'Auto Deploy' option selected.")
+  },{
+    cmd : 'fhc app stage --app=<cloud-app-id> --env=<environment> --runtime=<runtime> --gitRefType=<gitRef-type> --gitRefHash=<gitRef-hash>',
+    desc : i18n._("Deploy of cloud application <cloud-app-id> on <environment> with the <runtime> with 'branch' or 'tag' informed and the commit hash that you'd like to deploy.")
+  },{
+    cmd : 'fhc app stage --app=<cloud-app-id> --env=<environment> --runtime=<runtime> --gitRefValue=<gitRef-value>',
+    desc : i18n._("Deploy of cloud application <cloud-app-id> on <environment> with the <runtime> with the name of the branch that you'd like to deploy.")
+  }],
+  'demand' : ['app', 'env'],
+  'method' : 'post',
+  'alias' : {
+    'app' : 'a',
+    'env' : 'e',
+    'runtime' : 'r',
+    'clean' : 'c',
+    'autodeploy': 'ad',
+    'gitRefType' : 'gt',
+    'gitRefHash' : 'gh',
+    'gitRefValue' : 'gv',
+    0 : 'app',
+    1 : 'env'
+  },
+  'describe' : {
+    'app' : i18n._('Unique 24 character GUID of the cloud app you want to see resource info for'),
+    'env' : i18n._('The cloud environment your app is running in'),
+    'runtime' : i18n._("The Node.js runtime of your application. (E.g. node08, node010 or node4.). To check the available runtimes use '$fhc app runtimes --id=<cloud-app-id>'"),
+    'clean' : i18n._("Options 'true' or 'false'. Do a full, clean stage. Cleans out all old application log files, removes cached node modules and does an 'npm install' from scratch"),
+    'autodeploy' : i18n._("Options 'true' or 'false'. Deploy the app automatically when the app repo is updated"),
+    'gitRefType' : i18n._("Specifies if you'd like to deploy a 'branch' or 'tag'"),
+    'gitRefHash' : i18n._("The commit hash you'd like to deploy if gitRef.type is 'branch'. The default value is HEAD."),
+    'gitRefValue' : i18n._("The name of the branch you'd like to deploy")
+  },
+  'preCmd' : function(params, cb) {
+    var data = createData(params);
+    data = setDefaultBranchAsMaster(data);
+    data = setGitRefValue(params, data);
+    data = setGitRefHash(params, data);
 
-base.preCmd = function(argv, cb) {
-  var data = {
-    env: argv.env,
-    app: argv.app,
-    gitRef: argv.gitRef || {}
-  };
-
-  // Default to master like studio
-  if (!argv.gitRef) {
-    data.gitRef.type='branch';
-    data.gitRef.value='master';
-  }
-
-  if (argv.runtime) {
-    data.runtime = argv.runtime;
-  }
-  if (argv.clean) {
-    data.clean = argv.clean === 'true';
-  }
-  if (argv.autodeploy) {
-    data.autoDeploy = argv.autodeploy !== 'false';
-  }
-  // Default to HEAD if no hash is passed
-  if (argv.gitRef) {
-    if (!argv.gitRef.hash) {
-      data.gitRef.hash = 'HEAD';
+    if (params.gitRefType) {
+      if (params.gitRefType !== 'branch' && params.gitRefType !== 'tag') {
+        return cb(i18n._('Invalid parameter for gitRefType :' + params.gitRefType));
+      }
+      data.gitRef.type=params.gitRefType;
     }
-  }
 
-  return cb(null, data);
+    if (params.clean && (params.clean.toString() === 'true' || params.clean.toString() === 'false')) {
+      data.clean = params.clean;
+    } else if (params.clean) {
+      return cb(i18n._('Invalid param --clean value:') + params.clean);
+    }
+
+    if (params.autodeploy && (params.autodeploy.toString() === 'true' || params.autodeploy.toString() === 'false')) {
+      data.autodeploy = params.autodeploy;
+    } else if (params.clean) {
+      return cb(i18n._('Invalid param --autodeploy value:') + params.autodeploy);
+    }
+
+    if (params.runtime) {
+      checkRuntimeBeforeDoStage(params,data,cb);
+    } else {
+      return cb(null, data);
+    }
+  },
+  'url' : function(argv) {
+    var domain = ini.get("domain", "user");
+    var url = '/api/v2/mbaas/' + domain + '/' + argv.env +'/apps/' + argv.app + '/deploy';
+    return url;
+  },
+  'postCmd' : function(params, cb) {
+    async.map([params.cacheKey], common.waitFor, cb);
+  }
 };
-base.postCmd = function(params, cb) {
-  async.map([params.cacheKey], common.waitFor, cb);
-};
-module.exports = base;
+
+/**
+ * Check if the value informed to Runtime is valid or not
+ * @param data
+ * @param params
+ * @returns {*}
+ */
+function isValidRuntime(data, params) {
+  var found = false;
+  data.result.forEach(function(entry, index) {
+    if (data.result[index].name === params.runtime) {
+      found = true;
+    }
+  });
+  return found;
+}
+
+/**
+ * Define the default branch as Master.
+ * It is the same behavior of the NGUI/Studio
+ * @param data
+ * @returns {*}
+ */
+function setDefaultBranchAsMaster(data) {
+  data.gitRef.type = 'branch';
+  data.gitRef.value = 'master';
+  data.gitRef.hash = 'HEAD';
+  return data;
+}
+
+/**
+ * If the gitRefValue be informed set this values
+ * @param params
+ * @param data
+ * @returns {*}
+ */
+function setGitRefValue(params, data) {
+  if (params.gitRefValue) {
+    data.gitRef.type = 'branch';
+    data.gitRef.value = params.gitRefValue;
+  }
+  return data;
+}
+
+/**
+ * Set the git Ref Hash.
+ * The default value is HEAD
+ * @param params
+ * @param data
+ */
+function setGitRefHash(params,data) {
+  if (!params.gitRefHash) {
+    data.gitRef.hash = params.gitRefHash;
+  }
+  return data;
+}
+
+/**
+ * Create the object with all information to perform this operation
+ * @returns {{env: (string|*), app: *, gitRef: {}, runtime: (string|*|runtime|{openshift, dev, sp1-openshift, live}|{test, dev, multinode, live})}}
+ */
+function createData(params) {
+  var data = {
+    env: params.env,
+    app: params.app,
+    gitRef: {},
+    runtime: params.runtime
+  };
+  return data;
+}
+
+/**
+ * Check if the value definied to runtime is valid or not.
+ * If yes call perform action to stage/deploy the application
+ * @param params
+ * @param data
+ */
+function checkRuntimeBeforeDoStage(params,data,cb) {
+  var domain = ini.get("domain");
+  fhc.app.runtimes({id: params.app, domain: domain}, function(err, response) {
+    if (err) {
+      return cb(i18n._('Not found runtime: ' + err));
+    } else if (!response || !response.result || response.result.empty) {
+      return cb(i18n._('Not found the runtimes for this application.'));
+    } else if (!isValidRuntime(response, params)) {
+      return cb(i18n._('Invalid parameter for runtime!'));
+    } else {
+      return cb(null, data);
+    }
+  });
+}

--- a/test/unit/fh3/app/test_stage.js
+++ b/test/unit/fh3/app/test_stage.js
@@ -1,0 +1,110 @@
+var assert = require('assert');
+var genericCommand = require('genericCommand');
+var stageCommand = genericCommand(require('cmd/fh3/app/stage'));
+
+module.exports = {
+  'hapy test app stage deploy': function(cb) {
+    stageCommand.preCmd({
+      app: "j7hslnrb257zkr4qzjndoqkl",
+      env: "dev",
+    }, function(err) {
+      assert.equal(err, null);
+      return cb();
+    });
+  },
+  'hapy test app stage deploy clean as false': function(cb) {
+    stageCommand.preCmd({
+      app: "j7hslnrb257zkr4qzjndoqkl",
+      env: "dev",
+      clean:false
+    }, function(err) {
+      assert.equal(err, null);
+      return cb();
+    });
+  },
+  'hapy test app stage deploy autodeploy as false': function(cb) {
+    stageCommand.preCmd({
+      app: "j7hslnrb257zkr4qzjndoqkl",
+      env: "dev",
+      autodeploy:false
+    }, function(err) {
+      assert.equal(err, null);
+      return cb();
+    });
+  },
+  'hapy test app stage deploy gitRefType as tag': function(cb) {
+    stageCommand.preCmd({
+      app: "j7hslnrb257zkr4qzjndoqkl",
+      env: "dev",
+      gitRefType:"tag"
+    }, function(err) {
+      assert.equal(err, null);
+      return cb();
+    });
+  },
+  'hapy test app stage deploy gitRefHash': function(cb) {
+    stageCommand.preCmd({
+      app: "j7hslnrb257zkr4qzjndoqkl",
+      env: "dev",
+      gitRefHash:"946267f9858332c3a9dc70bc4b32fc6e21839e57"
+    }, function(err) {
+      assert.equal(err, null);
+      return cb();
+    });
+  },
+  'hapy test app stage deploy gitRefValue as master': function(cb) {
+    stageCommand.preCmd({
+      app: "j7hslnrb257zkr4qzjndoqkl",
+      env: "dev",
+      gitRefValue:"development"
+    }, function(err) {
+      assert.equal(err, null);
+      return cb();
+    });
+  },
+  'test app stage deploy gitRefType with invalid value': function(cb) {
+    stageCommand.preCmd({
+      app: "j7hslnrb257zkr4qzjndoqkl",
+      env: "dev",
+      gitRefType:"invalid"
+    }, function(err) {
+      assert.throws(
+        function() {
+          throw cb(i18n._('Invalid parameter for gitRefType :' + params.gitRefType));
+        },
+        Error
+      );
+      return cb();
+    });
+  },
+  'test app stage deploy clean with invalid value': function(cb) {
+    stageCommand.preCmd({
+      app: "j7hslnrb257zkr4qzjndoqkl",
+      env: "dev",
+      clean:"invalid"
+    }, function(err) {
+      assert.throws(
+        function() {
+          throw cb(i18n._('Invalid param --clean value: ' + params.clean));
+        },
+        Error
+      );
+      return cb();
+    });
+  },
+  'test app stage deploy autodeploy with invalid value': function(cb) {
+    stageCommand.preCmd({
+      app: "j7hslnrb257zkr4qzjndoqkl",
+      env: "dev",
+      autodeploy:"invalid"
+    }, function(err) {
+      assert.throws(
+        function() {
+          throw cb(i18n._('Invalid param --autodeploy value: ' + params.autodeploy));
+        },
+        Error
+      );
+      return cb();
+    });
+  }
+};


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RHMAP-15481

**Following the changes.**
* Add commands into the V3 format
* Unit tests for this command
* Fix the error issue by validating if the runtime informed is valid for the deploy. In this way, this issue so longer can occur.

**Steps to Verify**
1. Create a project into RHMAP and deploy the cloud app
2. Take the ID of the cloud app and try to run the app stage command with an invalid runtime.
Command :` fhc app stage --app=<cloud-app-id> --env=<env> --runtime=<runtime>`
Eg. `app stage --app=emqv364o7uhsrmph7imnvjv6 --env=dev --runtime=0010`

Following an example of the expected result. ( Local Test )

```
Camilas-MBP:fh-fhc cmacedo$ ./bin/fhc.js app stage --app=uwwl5ovobvc462szpjvx7y2u --env=dev --runtime=node010
Progress: 5%
Progress: 5%
[[
  {
    "action": {},
    "cacheKey": "1e2d2c327ce1a22e78b49e823191f4f2",
    "error": "",
    "log": [
      "Pre-deploy checks passed",
      "Deploy operation scheduled",
      "Checking app runtime\n Runtime is ok. Creating app\n [stdout] Package.json unchanged, not running npm.\n Updating app state\n Starting app\n App deployed\n "
    ],
    "progress": 5,
    "status": "complete"
  }
]]
Camilas-MBP:fh-fhc cmacedo$ ./bin/fhc.js app stage --app=uwwl5ovobvc462szpjvx7y2u --env=dev --runtime=node
fhc ERR! Invalid parameter for runtime!
fhc Command executed with error
Camilas-MBP:fh-fhc cmacedo$ 

```
 

