### PR TITLE
RHMAP-12406 - FHC tool - Check if the tag is valid or not before doin…

### DIFF
--- a/lib/cmd/common/build.js
+++ b/lib/cmd/common/build.js
@@ -43,14 +43,17 @@ var _ = require("underscore");
 
 function build(argv, cb) {
   var args = argv._;
+
   try {
     var argObj = common.parseArgs(args);
     validateArgs(argObj);
+    mutateGitRefArgs(argObj);
     if (isNGUI()) {
       validateArgsNgui(argObj);
+      doBuildAfterCheckIfIsValidTag(argObj,cb);
+    } else {
+      doBuild(argObj, cb);
     }
-    mutateGitRefArgs(argObj);
-    doBuild(argObj, cb);
   } catch (x) {
     log.silly(x);
     return cb(i18n._("Error processing args: ") + x + "\n" + i18n._("Usage: ") + isNGUI ? build.usage_ngui : build.usage);
@@ -183,6 +186,25 @@ function mutateGitRefArgs(args) {
     };
     clearGitParams(args);
     return;
+  }
+}
+
+function doBuildAfterCheckIfIsValidTag(argObj,cb) {
+  if (argObj.tag) {
+    var url = "box/api/projects/" + argObj.project + '/connections';
+    common.doGetApiCall(fhreq.getFeedHenryUrl(), url, i18n._("Error reading Connections: "), function(err, conns) {
+      if (err) {
+        return cb(err);
+      }
+      _.each(conns, function(connection) {
+        if (connection.clientApp === argObj.app && argObj.tag === connection.tag) {
+          return cb(i18n._("This tag is currently in use, please choose another."));
+        }
+      });
+      doBuild(argObj,cb);
+    });
+  } else {
+    doBuild(argObj,cb);
   }
 }
 


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RHMAP-12406
Change: Make a validation for the tag value as it is made into the studio. ( don't allow builds with used tag connections ) 

Following the local tests to check.

**Error of this validation(changes)**

```
Camilas-MacBook-Pro:fh-fhc cmacedo$ ./bin/fhc.js build project=qei6x6jgfwgrrzpi4v6ifuej app=qei6x6nrkiamo6frercbc4ps cloud_app=qei6x6pzt7tne5f2gx2wootn environment=dev destination=android tag=4.0.3
(node) sys is deprecated. Use util instead.
fhc ERR! This tag is currently in use, please choose another.
fhc Command executed with error
```
**Success with tag and changes**

```
Camilas-MacBook-Pro:fh-fhc cmacedo$ ./bin/fhc.js build project=qei6x6jgfwgrrzpi4v6ifuej app=qei6x6nrkiamo6frercbc4ps cloud_app=qei6x6pzt7tne5f2gx2wootn environment=dev destination=android tag=5.0.3
(node) sys is deprecated. Use util instead.
.......................
Download URL: https://support.us.feedhenry.com/digman/android-v3/dist/5a8a6d97-dd5b-43ce-a07a-4b119bb63b1d/android~4.0~61~CordovaApp.apk?digger=diggers.sam1-farm2-linux1
```
**Sucess without tag**

```
Camilas-MacBook-Pro:fh-fhc cmacedo$ ./bin/fhc.js build project=qei6x6jgfwgrrzpi4v6ifuej app=qei6x6nrkiamo6frercbc4ps cloud_app=qei6x6pzt7tne5f2gx2wootn environment=dev destination=android 
(node) sys is deprecated. Use util instead.
...........
Download URL: https://support.us.feedhenry.com/digman/android-v3/dist/fbb39f88-7e7f-4461-b384-46ead9107136/android~4.0~62~CordovaApp.apk?digger=diggers.sam1-farm2-linux1
Camilas-MacBook-Pro:fh-fhc cmacedo$ 
```
