### PR TITLE
FH-3458 - Remove block to use fhc with upper versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "turbo-test-runner": "0.3.3"
   },
   "engines": {
-    "node": ">=0.10 <= 4.4"
+    "node": ">=0.10"
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/FH-3458
Public Issue: https://github.com/feedhenry/fh-fhc/issues/297

Following Local Test

```
Camilas-MacBook-Pro:fh-fhc cmacedo$ fhc target
fhc ERR! unsupported version 
fhc ERR! unsupported version fhc requires node version: >=0.10 <= 4.4
fhc ERR! unsupported version And you have: v4.5.0
fhc ERR! unsupported version which is not satisfactory.
fhc ERR! unsupported version 
https://support.us.feedhenry.com/
Camilas-MacBook-Pro:fh-fhc cmacedo$ ./bin/fhc.js target
(node) sys is deprecated. Use util instead.
https://support.us.feedhenry.com/

```