### PR TITLE
RHMAP-15721-Fix command `admin status` and add it to V3 standard with unit tests

### DIFF
--- a/lib/cmd/fh3/admin/status.js
+++ b/lib/cmd/fh3/admin/status.js
@@ -1,33 +1,28 @@
 /* globals i18n */
-module.exports = status;
-
-status.desc = i18n._("Manage status");
-status.usage = "fhc admin status \n fhc admin status <component> \n";
-status.perm = "cluster:read";
-
-var fhreq = require("../../../utils/request");
-
-function status(argv, cb) {
-  var args = argv._;
-  if (args.length < 1) {
-    return unknown(i18n._("Invalid arguments"), cb);
+var common = require('../../../common.js');
+module.exports = {
+  'desc' : i18n._('Check status of this domain/millicore'),
+  'examples' :
+  [{
+    cmd : 'fhc admin status',
+    desc : i18n._('Check status of this domain/millicore')
+  },{
+    cmd : 'fhc admin status --json',
+    desc : i18n._('Check status of this domain/millicore with the output as json')
+  }],
+  'demand' : [],
+  'alias' : {
+    'json' : 'j',
+    0 : 'json'
+  },
+  'describe' : {
+    'json' : i18n._('Output of this command in json format')
+  },
+  'perm' : "cluster/reseller/customer:read",
+  'url' : '/box/api/status',
+  'method' : 'get',
+  'postCmd': function(params, cb) {
+    params._table = common.createTableForStatus(params);
+    return cb(null, params);
   }
-  if (args.length === 1) {
-    switch (args[0].toLocaleLowerCase()) {
-    case "millicore":
-      return millicoreStatus(cb);
-    default:
-      return unknown(i18n._("Invalid component"), cb);
-    }
-  }
-}
-
-function millicoreStatus(cb) {
-  fhreq.GET(fhreq.getFeedHenryUrl(), "/box/api/status", i18n._("error getting status"), function(err, ok) {
-    cb(err, ok);
-  });
-}
-
-function unknown(message, cb) {
-  return cb(message + "\n" + i18n._("Usage: \n") + status.usage);
-}
+};

--- a/lib/common.js
+++ b/lib/common.js
@@ -480,6 +480,19 @@ exports.createTableForEnvironments = function(environments) {
   return table;
 };
 
+exports.createTableForStatus = function(result) {
+  var table = new Table({
+    head: ['Status', result.status],
+    style: exports.style()
+  });
+  table.push(['ampq', result.summary.amqp]);
+  table.push(['db', result.summary.db]);
+  table.push(['cache', result.summary.cache]);
+  table.push(['git', result.summary.git]);
+
+  return table;
+};
+
 exports.createTableForRuntimes = function(runtimes) {
   var table = new Table({
     head: ['Name', 'Description', 'Version', 'Npm Version'],

--- a/test/fixtures/admin/fixture_status.js
+++ b/test/fixtures/admin/fixture_status.js
@@ -1,0 +1,16 @@
+var nock = require('nock');
+
+module.exports = nock('https://apps.feedhenry.com')
+.filteringRequestBody(function() {
+  return '*';
+})
+.get('/box/api/status', '*')
+.reply(200, {
+  "status": "ok",
+  "summary": {
+    "amqp": "ok",
+    "db": "ok",
+    "cache": "ok",
+    "git": "ok"
+  }
+})

--- a/test/unit/fh3/admin/test_status.js
+++ b/test/unit/fh3/admin/test_status.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+var genericCommand = require('genericCommand');
+var _ = require('underscore');
+require('test/fixtures/admin/fixture_status');
+var adminstatus = genericCommand(require('cmd/fh3/admin/status'));
+
+module.exports = {
+  'test admin status': function(cb) {
+    adminstatus({}, function(err, data) {
+      assert.equal(err, null);
+      assert.equal(data.status,'ok');
+      return cb();
+    });
+  }
+};


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RHMAP-15721

Changes:
* Fix the command. It was not working before
* Add it into the V3 standard 
* Add unit test
* Improve output

Following local test 

<img width="493" alt="screen shot 2017-05-24 at 1 21 12 am" src="https://cloud.githubusercontent.com/assets/7708031/26386979/8f4ad69c-4020-11e7-9564-546791ead3af.png">

Following the local test with --json flag

```
Camilas-MacBook-Pro:fh-fhc cmacedo$ ./bin/fhc.js admin status --json
(node) sys is deprecated. Use util instead.
{
  "status": "ok",
  "summary": {
    "amqp": "ok",
    "db": "ok",
    "cache": "ok",
    "git": "ok"
  }
}

```
Following the local test to check the help.

````
Camilas-MacBook-Pro:fh-fhc cmacedo$ ./bin/fhc.js help admin status
(node) sys is deprecated. Use util instead.
Usage:
 fhc admin status [--json=<json>]

Examples:
  fhc admin status           Check status of this domain/millicore
  fhc admin status --json    Check status of this domain/millicore with the output as json


Options:
  --json, -j  Output of this command in json format

Camilas-MacBook-Pro:fh-fhc cmacedo$ 
````

Following the local test with the alias 

`````
Camilas-MacBook-Pro:fh-fhc cmacedo$ ./bin/fhc.js admin status -j
(node) sys is deprecated. Use util instead.
{
  "status": "ok",
  "summary": {
    "amqp": "ok",
    "db": "ok",
    "cache": "ok",
    "git": "ok"
  }
}
Camilas-MacBook-Pro:fh-fhc cmacedo$ 
`````
