### PR TITLE
RHMAP-15725 - Add command `fhc ping` to V3 standard and add unit test

### DIFF
--- a/lib/cmd/fh3/ping.js
+++ b/lib/cmd/fh3/ping.js
@@ -1,56 +1,51 @@
 /* globals i18n */
-module.exports = ping;
-ping.ping = ping;
-
-ping.usage = "fhc ping <app-id> --env=<environment>";
-ping.desc = i18n._("Ping a FeedHenry cloud app");
-
 var log = require("../../utils/log");
 var fhc = require("../../fhc");
-var common = require("../../common");
-var ini = require('../../utils/ini');
 var request = require('request');
 var util = require('util');
 
-// Main ping entry point
-function ping(argv, cb) {
-  var args = argv._;
-  if (args.length === 0) {
-    return cb(ping.usage);
-  }
-
-  var appId = fhc.appId(args[0]);
-  var environment = ini.getEnvironment(argv);
-
-  // lookup host for environment and ping it directly
-  var params = {
-    app: appId,
-    env: environment
-  };
-  log.info('host params' + util.inspect(params));
-  fhc.app.hosts(params, function(err, host) {
-    log.silly('host res:' + util.inspect(arguments));
-    if (err) {
-      return cb(err);
-    }
-    var proxyRequest = request.defaults({'proxy': fhc.config.get("proxy")});
-    proxyRequest(host.url + '/sys/info/ping', function(err, res, body) {
-      log.silly('req res:' + util.inspect(arguments));
+module.exports = {
+  'desc' : i18n._('Ping a cloud app'),
+  'examples' : [{
+    cmd : 'fhc ping --app=<app> --env=<environment>',
+    desc : i18n._('Ping the cloud application <app-id>')}],
+  'demand' : ['app', 'env'],
+  'alias' : {
+    'app':'a',
+    'env':'e',
+    0 : 'app',
+    1 : 'env'
+  },
+  'describe' : {
+    'app' : i18n._("Unique 24 character GUID of your cloud application."),
+    'env' : i18n._("Unique 24 character GUID of the environment where this cloud application is deployed.")
+  },
+  'customCmd': function(argv, cb) {
+    // lookup host for environment and ping it directly
+    var params = {
+      app: argv.app,
+      env: argv.env
+    };
+    log.info('host params' + util.inspect(params));
+    fhc.app.hosts(params, function(err, host) {
+      log.silly('host res:' + util.inspect(arguments));
       if (err) {
         return cb(err);
       }
+      var proxyRequest = request.defaults({'proxy': fhc.config.get("proxy")});
+      proxyRequest(host.url + '/sys/info/ping', function(err, res, body) {
+        log.silly('req res:' + util.inspect(arguments));
+        if (err) {
+          return cb(err);
+        }
 
-      log.info('res.statusCode:' + res.statusCode + ' body:' + body);
-      if (res.statusCode < 200 || res.statusCode >= 300) {
-        return cb(util.format(i18n._('Non 2xx response "%s"'), body));
-      }
+        log.info('res.statusCode:' + res.statusCode + ' body:' + body);
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          return cb(util.format(i18n._('Non 2xx response "%s"'), body));
+        }
 
-      return cb(null, body);
+        return cb(null, body);
+      });
     });
-  });
-}
-
-// bash completion
-ping.completion = function(opts, cb) {
-  common.getAppIds(cb);
+  }
 };

--- a/test/fixtures/fixture_ping.js
+++ b/test/fixtures/fixture_ping.js
@@ -1,0 +1,6 @@
+var nock = require('nock');
+var data = "OK";
+
+module.exports = nock('https://apps.feedhenry.com')
+  .get('/sys/info/ping')
+  .reply(200, data);

--- a/test/unit/fh3/test_ping.js
+++ b/test/unit/fh3/test_ping.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+var genericCommand = require('genericCommand');
+var _ = require('underscore');
+require('test/fixtures/admin/fixture_ping');
+var pingCmd = genericCommand(require('cmd/fh3/ping'));
+
+module.exports = {
+  'test artifacts app': function(cb) {
+    pingCmd({app:'1a'}, function(err, data) {
+      assert.equal(err, null);
+      assert.equal(data, "OK");
+      return cb();
+    });
+  }
+};


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RHMAP-15725

Following the changes made.
* Add it into the V3 standard
* Add unit test

Following local test when the cloud app is started.

`````
Camilas-MacBook-Pro:fh-fhc cmacedo$ ./bin/fhc.js ping invchzy3wemcaef2lokcayzd dev
(node) sys is deprecated. Use util instead.
"OK"
Camilas-MacBook-Pro:fh-fhc cmacedo$ 
``````

Following the local test when the cloud app is stoped.

`````
Camilas-MacBook-Pro:fh-fhc cmacedo$ ./bin/fhc.js ping invchzy3wemcaef2lokcayzd dev
(node) sys is deprecated. Use util instead.
fhc ERR! Non 2xx response "Service unavailable, check service exists and is running ok - { [Error: connect ECONNREFUSED 172.22.0.5:8201]
fhc ERR!   code: 'ECONNREFUSED',
fhc ERR!   errno: 'ECONNREFUSED',
fhc ERR!   syscall: 'connect',
fhc ERR!   address: '172.22.0.5',
fhc ERR!   port: 8201 }"
fhc Command executed with error
Camilas-MacBook-Pro:fh-fhc cmacedo$ 

````