### PR TITLE
RHMAP-15723 - Add command `fhc clone` to V3 standard

### DIFF
--- a/lib/cmd/fh3/app/read.js
+++ b/lib/cmd/fh3/app/read.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   'describe' : {
     'project' : i18n._('Unique 24 character GUID of the project your app lives in'),
-    'app' : i18n._('Unique 24 character GUID of the app you want to delete'),
+    'app' : i18n._('Unique 24 character GUID of the app you want to read')
   },
   'url' : function(argv) {
     return "box/api/projects/" + argv.project + "/apps/" + fhc.appId(argv.app);

--- a/lib/cmd/fh3/clone.js
+++ b/lib/cmd/fh3/clone.js
@@ -1,24 +1,33 @@
 /* globals i18n */
-module.exports = clone;
-
-clone.usage = "fhc clone <project-id> <app-id> [<local-dir>]";
-clone.desc = i18n._("Performs a git clone of a feedhenry application");
-
 var log = require("../../utils/log");
-var common = require("../../common");
-var _ = require('underscore');
-var read = require('../fh2/app/read.js');
+var fhc = require("../../fhc");
 
-function clone(argv, cb) {
-  var args = argv._;
-  if (args.length < 2) {
-    return cb(clone.usage);
+module.exports = {
+  'desc' : i18n._('Performs a git clone of an application'),
+  'examples' : [{
+    cmd : 'fhc clone --project=<project> --app=<app> --local=<local>',
+    desc : i18n._('Performs a git clone of the <app> from the project <project> into the path <local>')}],
+  'demand' : ['project', 'app'],
+  'alias' : {
+    'project':'p',
+    'app':'a',
+    'local':'a',
+    0 : 'project',
+    1 : 'app',
+    2 : 'local'
+  },
+  'describe' : {
+    'app' : i18n._("Unique 24 character GUID of your application."),
+    'project' : i18n._("Unique 24 character GUID of your project"),
+    'local' : i18n._("Path where you want the application be cloned")
+  },
+  'customCmd': function(argv, cb) {
+    doClone(argv.project, argv.app, argv.local, cb);
   }
-  doClone(args[0], args[1], args[2], cb);
-}
+};
 
 function doClone(projectId, appId, localDir, cb) {
-  read({_: [projectId, appId]}, function(err, app) {
+  fhc.app.read({ project:projectId, app:appId}, function(err, app) {
     if (err) {
       return cb(err);
     }
@@ -45,24 +54,7 @@ function gitClone(url, branch, localDir, cb) {
     if (err) {
       return cb(err);
     }
-    return cb(undefined, {stdout: stdout, stderr: stderr});
+    var message = stdout + stderr;
+    return cb(undefined, message);
   });
 }
-
-// bash completion
-clone.completion = function(opts, cb) {
-  var argv = opts.conf.argv.remain;
-  if (argv.length === 2) {
-    return common.getProjectIds(cb);
-  }
-
-  if (argv.length === 3) {
-    var projectId = argv[2];
-    common.listApps(projectId, function(err, apps) {
-      if (err) {
-        return cb(null, []);
-      }
-      return cb(null, _.pluck(apps.list, 'guid'));
-    });
-  }
-};


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RHMAP-15723

Following the changes made.
* Add it to the V3 standard
* Remove call to use the V2 command. Use the same command but V3 
* Fix output
* Fix description test of the `fhc app read` command which is used here. 

Following local tests

Test when the clone is made.
`````
Camilas-MacBook-Pro:fh-fhc cmacedo$ ./bin/fhc.js clone invchzzwmwnpwehmy54roimi invchzy3wemcaef2lokcayzd 
(node) sys is deprecated. Use util instead.
Cloning into 'TestAllHello-Cloud-App'...
##########################################################################
# THIS SYSTEM IS RESTRICTED TO AUTHORIZED USERS FOR AUTHORIZED USE ONLY. #
# UNAUTHORIZED ACCESS IS STRICTLY PROHIBITED AND MAY BE PUNISHABLE UNDER #
# THE COMPUTER FRAUD AND ABUSE ACT OF 1986 OR OTHER APPLICABLE LAWS.     #
# IF NOT AUTHORIZED TO ACCESS THIS SYSTEM, DISCONNECT NOW.               #
# BY CONTINUING, YOU CONSENT TO YOUR KEYSTROKES AND DATA CONTENT BEING   #
# MONITORED. ALL PERSONS ARE HEREBY NOTIFIED THAT THE USE OF THIS SYSTEM #
# CONSTITUTES CONSENT TO MONITORING AND AUDITING.                        #
##########################################################################

Camilas-MacBook-Pro:fh-fhc cmacedo$ 
``````
Test when the app was already cloned.
``````
Camilas-MacBook-Pro:fh-fhc cmacedo$ ./bin/fhc.js clone invchzzwmwnpwehmy54roimi invchzy3wemcaef2lokcayzd 
(node) sys is deprecated. Use util instead.
fhc ERR! Error: Command failed: /bin/sh -c git clone git@git.us.feedhenry.com:support/TestAllHello-Cloud-App.git -b master
fhc ERR! fatal: destination path 'TestAllHello-Cloud-App' already exists and is not an empty directory.
fhc ERR! 
fhc ERR! 
fhc ERR! System Darwin 15.6.0
fhc ERR! command "/Users/cmacedo/.nvm/versions/node/v4.4.3/bin/node" "/Users/cmacedo/work/fh-fhc/bin/fhc.js" "clone" "invchzzwmwnpwehmy54roimi" "invchzy3wemcaef2lokcayzd"
fhc Command executed with error
`````