### PR TITLE
FH-3616 - Remove the Warn: sys is deprecated. Use util instead. from FHC tool

### DIFF
--- a/lib/utils/exec.js
+++ b/lib/utils/exec.js
@@ -4,7 +4,7 @@ exec.pipe = pipe;
 
 var log = require("./log");
 var child_process = require("child_process");
-var sys = require("./sys");
+var util = require("util");
 var fhc = require("../fhc");
 var myUID = process.getuid ? process.getuid() : null;
 var myGID = process.getgid ? process.getgid() : null;
@@ -86,7 +86,7 @@ function logger(d) {
   }
 }
 function pipe(cp1, cp2, cb) {
-  sys.pump(cp1.stdout, cp2.stdin);
+  util.pump(cp1.stdout, cp2.stdin);
   var errState = null
     , buff1 = ""
     , buff2 = "";

--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -84,8 +84,8 @@ log.waitForConfig = function() {
 
 // now the required stuff has been loaded,
 // so the transitive module dep will work
-var sys = require("./sys")
-  , fhc = require("../fhc");
+var util = require("util");
+var fhc = require("../fhc");
 
 Object.defineProperty(log, "level",
   {
@@ -98,7 +98,7 @@ Object.defineProperty(log, "level",
       if (!isNaN(show)) {
         show = +show;
       } else if (!LEVEL.hasOwnProperty(show)) {
-        sys.error("Invalid loglevel config: "+JSON.stringify(show));
+        util.error("Invalid loglevel config: "+JSON.stringify(show));
         show = "info";
       }
       if (isNaN(show)) {
@@ -190,7 +190,7 @@ fhc.on("log", function(logData) {
     return cb();
   }
   if (typeof msg !== "string" && !(msg instanceof Error)) {
-    msg = sys.inspect(msg, 0, 4, true);
+    msg = util.inspect(msg, 0, 4, true);
   }
 
   // console.error("level, showlevel, show", level, show, (level >= show))

--- a/lib/utils/output.js
+++ b/lib/utils/output.js
@@ -8,7 +8,7 @@ exports.write = write;
 var fhc = require("../fhc.js");
 var streams = {};
 var net = require("net");
-var sys = require("./sys");
+var util = require("util");
 var tty = require("tty");
 
 function doColor(stream) {
@@ -68,7 +68,7 @@ function write(args, stream, lf, cb) {
   msg =  args.map(function(arg) {
     if (typeof arg !== "string") {
       if (fhc.config.get('usesysinspect')) {
-        return sys.inspect(arg, false, 5, colored) + "\n";
+        return util.inspect(arg, false, 5, colored) + "\n";
       }
       return JSON.stringify(arg, null, fhc.config.get('jsondepth'));
     }

--- a/lib/utils/sys.js
+++ b/lib/utils/sys.js
@@ -1,1 +1,0 @@
-module.exports = require(!process.binding("natives").util ? "util" : "sys");


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/FH-3616

Following the local test. 

<img width="633" alt="screen shot 2017-05-31 at 6 10 16 pm" src="https://cloud.githubusercontent.com/assets/7708031/26654218/5f04b02c-462c-11e7-87cb-9254afeccc73.png">
