### PR TITLE
FH-3411 - fh-fhc upload app binary does not use proxy setting

### DIFF
--- a/lib/cmd/common/admin-storeitems.js
+++ b/lib/cmd/common/admin-storeitems.js
@@ -19,6 +19,8 @@ storeitems.usage = "\nfhc admin-storeitems list"
 
 var fhreq = require("../../utils/request");
 var common = require("../../common");
+var fs = require('fs');
+var util = require('util');
 
 function storeitems(argv, cb) {
   var args = argv._;
@@ -189,7 +191,17 @@ function addIcon(guid, iconFile, cb) {
 }
 
 function addBinary(guid, type, binary, cb) {
-  fhreq.uploadFile("/box/srv/1.1/admin/storeitem/uploadbinary", binary, {"type":type,"guid":guid},  "application/octet-stream", cb);
+  var dataObject = [{
+    name: 'type',
+    'value': type
+  },{
+    name: 'guid',
+    'value': guid
+  },{
+    name: 'file',
+    'value': fs.createReadStream(binary)
+  }];
+  fhreq.doRequestWithDataObjectValues("/box/srv/1.1/admin/storeitem/uploadbinary", dataObject, null,  util.format(i18n._("Binary '%s' uploaded successfully"),binary), cb);
 }
 
 // add groups to a storeitem


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/FH-3411

**Following the commands to test it.** 
```
$ fhc fhcfg set proxy <proxy>
$ ./bin/fhc.js admin-storeitems uploadbinary 5w477lfgy3jrnovri7gctsb7 android test.txt 
```

**Following local test.**



- **With an invalid value for the proxy, it doesn't  work.** 
````
Camilas-MacBook-Pro:fh-fhc cmacedo$ fhc fhcfg set proxy "70.35.197.74:80"
(node) sys is deprecated. Use util instead.

Camilas-MacBook-Pro:fh-fhc cmacedo$ ./bin/fhc.js admin-storeitems uploadbinary 5w477lfgy3jrnovri7gctsb7 android test.txt 
fhc WARN Error checking latest version
fhc ERR! Error Uploading File Error: tunneling socket could not be established, cause=connect EHOSTUNREACH 0.0.0.80:80 - Local (192.168.1.59:61566)
fhc Command executed with error
Camilas-MacBook-Pro:fh-fhc cmacedo$ 
````
- **With a valid proxy, it worked successfully.**
````
Camilas-MacBook-Pro:fh-fhc cmacedo$ fhc fhcfg set proxy "http://70.35.197.74:80"
(node) sys is deprecated. Use util instead.

Camilas-MacBook-Pro:fh-fhc cmacedo$ ./bin/fhc.js admin-storeitems uploadbinary 5w477lfgy3jrnovri7gctsb7 android test.txt 
Binary 'test.txt' uploaded successfully

````

- **Without the proxy, it still working successfully.**

````
Camilas-MacBook-Pro:fh-fhc cmacedo$ fhc fhcfg set proxy " "
(node) sys is deprecated. Use util instead.

Camilas-MacBook-Pro:fh-fhc cmacedo$ ./bin/fhc.js admin-storeitems uploadbinary 5w477lfgy3jrnovri7gctsb7 android test.txt 
Binary 'test.txt' uploaded successfully
````

The file was checked into the studio either. 