### PR TITLE
FH 3657 - Improve output data when the commands has table in the output and they are used as dependency

### DIFF
--- a/lib/cmd/common/version.js
+++ b/lib/cmd/common/version.js
@@ -37,7 +37,7 @@ module.exports = {
       return cb(null, params);
     });
   },
-  postCmd: function(params, cb) {
+  postCmd: function(argv, params, cb) {
     if (this.format && this.format.toLowerCase() === 'json') {
       return cb(null, this.getJsonMessage(params));
     } else {

--- a/lib/cmd/fh3/admin/domains/check.js
+++ b/lib/cmd/fh3/admin/domains/check.js
@@ -24,7 +24,9 @@ module.exports = {
   },
   'method' : 'get',
   'postCmd': function(argv, params, cb) {
-    params._table = common.createObjectTable(params);
+    if (!argv.json) {
+      params._table = common.createObjectTable(params);
+    }
     return cb(null, params);
   }
 };

--- a/lib/cmd/fh3/admin/domains/check.js
+++ b/lib/cmd/fh3/admin/domains/check.js
@@ -23,7 +23,7 @@ module.exports = {
     return "/box/api/domains/check?domain=" + domain;
   },
   'method' : 'get',
-  'postCmd': function(params, cb) {
+  'postCmd': function(argv, params, cb) {
     params._table = common.createObjectTable(params);
     return cb(null, params);
   }

--- a/lib/cmd/fh3/admin/environments/list.js
+++ b/lib/cmd/fh3/admin/environments/list.js
@@ -13,7 +13,9 @@ module.exports = {
   'url': '/api/v2/environments/all',
   'method': 'get',
   'postCmd': function(argv, params, cb) {
-    params._table = common.createTableForEnvironments(params);
+    if (!argv.json) {
+      params._table = common.createTableForEnvironments(params);
+    }
     return cb(null, params);
   }
 };

--- a/lib/cmd/fh3/admin/environments/list.js
+++ b/lib/cmd/fh3/admin/environments/list.js
@@ -12,7 +12,7 @@ module.exports = {
   'describe': {},
   'url': '/api/v2/environments/all',
   'method': 'get',
-  'postCmd': function(params, cb) {
+  'postCmd': function(argv, params, cb) {
     params._table = common.createTableForEnvironments(params);
     return cb(null, params);
   }

--- a/lib/cmd/fh3/admin/logs/syslogs.js
+++ b/lib/cmd/fh3/admin/logs/syslogs.js
@@ -69,7 +69,7 @@ module.exports = {
 
     return cb(null, searchParams);
   },
-  'postCmd': function(searchResults, cb) {
+  'postCmd': function(argv, searchResults, cb) {
     searchResults._table = common.createTableForSyslogs(searchResults);
 
     return cb(null, searchResults);

--- a/lib/cmd/fh3/admin/logs/syslogs.js
+++ b/lib/cmd/fh3/admin/logs/syslogs.js
@@ -70,8 +70,9 @@ module.exports = {
     return cb(null, searchParams);
   },
   'postCmd': function(argv, searchResults, cb) {
-    searchResults._table = common.createTableForSyslogs(searchResults);
-
+    if (!argv.json) {
+      searchResults._table = common.createTableForSyslogs(searchResults);
+    }
     return cb(null, searchResults);
   }
 };

--- a/lib/cmd/fh3/admin/mbaas/list.js
+++ b/lib/cmd/fh3/admin/mbaas/list.js
@@ -12,7 +12,7 @@ module.exports = {
   'describe': {},
   'url': '/api/v2/mbaases',
   'method': 'get',
-  'postCmd': function(params, cb) {
+  'postCmd': function(argv, params, cb) {
     params._table = common.createTableForMbaasTargets(params);
     return cb(null, params);
   }

--- a/lib/cmd/fh3/admin/mbaas/list.js
+++ b/lib/cmd/fh3/admin/mbaas/list.js
@@ -13,7 +13,9 @@ module.exports = {
   'url': '/api/v2/mbaases',
   'method': 'get',
   'postCmd': function(argv, params, cb) {
-    params._table = common.createTableForMbaasTargets(params);
+    if (!argv.json) {
+      params._table = common.createTableForMbaasTargets(params);
+    }
     return cb(null, params);
   }
 };

--- a/lib/cmd/fh3/admin/status.js
+++ b/lib/cmd/fh3/admin/status.js
@@ -21,7 +21,7 @@ module.exports = {
   'perm' : "cluster/reseller/customer:read",
   'url' : '/box/api/status',
   'method' : 'get',
-  'postCmd': function(params, cb) {
+  'postCmd': function(argv, params, cb) {
     params._table = common.createTableForStatus(params);
     return cb(null, params);
   }

--- a/lib/cmd/fh3/admin/status.js
+++ b/lib/cmd/fh3/admin/status.js
@@ -22,7 +22,9 @@ module.exports = {
   'url' : '/box/api/status',
   'method' : 'get',
   'postCmd': function(argv, params, cb) {
-    params._table = common.createTableForStatus(params);
+    if (!argv.json) {
+      params._table = common.createTableForStatus(params);
+    }
     return cb(null, params);
   }
 };

--- a/lib/cmd/fh3/admin/teams/list.js
+++ b/lib/cmd/fh3/admin/teams/list.js
@@ -9,7 +9,7 @@ module.exports = {
   'describe' : {},
   'url' : "api/v2/admin/teams",
   'method' : 'get',
-  'postCmd': function(params, cb) {
+  'postCmd': function(argv, params, cb) {
     params._table = common.createTableForTeams(params);
     return cb(null, params);
   }

--- a/lib/cmd/fh3/admin/teams/list.js
+++ b/lib/cmd/fh3/admin/teams/list.js
@@ -1,5 +1,4 @@
 /* globals i18n */
-
 var common = require('../../../../common.js');
 module.exports = {
   'desc' : i18n._('Lists teams.'),
@@ -10,7 +9,9 @@ module.exports = {
   'url' : "api/v2/admin/teams",
   'method' : 'get',
   'postCmd': function(argv, params, cb) {
-    params._table = common.createTableForTeams(params);
+    if (!argv.json) {
+      params._table = common.createTableForTeams(params);
+    }
     return cb(null, params);
   }
 };

--- a/lib/cmd/fh3/app/create.js
+++ b/lib/cmd/fh3/app/create.js
@@ -80,7 +80,7 @@ module.exports = {
       });
     }
   },
-  'postCmd': function(params, cb) {
+  'postCmd': function(argv, params, cb) {
     if (args && (args.wait === true || args.wait === 'true')) {
       async.map([params.scmCacheKey], common.waitFor, function(err, logs) {
         if (err) {

--- a/lib/cmd/fh3/app/list.js
+++ b/lib/cmd/fh3/app/list.js
@@ -18,7 +18,7 @@ module.exports = {
     return "box/api/projects/" + argv.project;
   },
   'method' : 'get',
-  'postCmd' : function(params, cb) {
+  'postCmd' : function(argv, params, cb) {
     params._table = common.createTableForProjectApps(params.guid, params.apps);
     return cb(null, params);
   }

--- a/lib/cmd/fh3/app/list.js
+++ b/lib/cmd/fh3/app/list.js
@@ -19,7 +19,9 @@ module.exports = {
   },
   'method' : 'get',
   'postCmd' : function(argv, params, cb) {
-    params._table = common.createTableForProjectApps(params.guid, params.apps);
+    if (!argv.json) {
+      params._table = common.createTableForProjectApps(params.guid, params.apps);
+    }
     return cb(null, params);
   }
 };

--- a/lib/cmd/fh3/app/runtimes.js
+++ b/lib/cmd/fh3/app/runtimes.js
@@ -26,7 +26,7 @@ module.exports = {
   'url': function(argv) {
     return "/api/v2/mbaas/" + argv.domain + "/" + argv.env +"/apps/" + argv.id + "/runtimes";
   },
-  'postCmd': function(response, cb) {
+  'postCmd': function(argv, response, cb) {
     if (response.code === 200) {
       response._table = common.createTableForRuntimes(response.result);
       return cb(null, response);

--- a/lib/cmd/fh3/app/runtimes.js
+++ b/lib/cmd/fh3/app/runtimes.js
@@ -27,10 +27,10 @@ module.exports = {
     return "/api/v2/mbaas/" + argv.domain + "/" + argv.env +"/apps/" + argv.id + "/runtimes";
   },
   'postCmd': function(argv, response, cb) {
-    if (response.code === 200) {
+    if (!argv.json && response.code === 200) {
       response._table = common.createTableForRuntimes(response.result);
-      return cb(null, response);
     }
+    return cb(null, response);
   },
   'preCmd': function(params, cb) {
     var request = {

--- a/lib/cmd/fh3/app/stage.js
+++ b/lib/cmd/fh3/app/stage.js
@@ -80,7 +80,7 @@ module.exports = {
     var url = '/api/v2/mbaas/' + domain + '/' + argv.env +'/apps/' + argv.app + '/deploy';
     return url;
   },
-  'postCmd' : function(params, cb) {
+  'postCmd' : function(argv, params, cb) {
     async.map([params.cacheKey], common.waitFor, cb);
   }
 };

--- a/lib/cmd/fh3/appdata/export/list.js
+++ b/lib/cmd/fh3/appdata/export/list.js
@@ -20,7 +20,7 @@ module.exports = {
   'url': function(params) {
     return 'api/v2/appdata/' + params.envId + '/' + params.appId + '/data/export';
   },
-  'postCmd': function(params, cb) {
+  'postCmd': function(argv, params, cb) {
     params._table = common.createTableForAppData(params);
     return cb(null, params);
   }

--- a/lib/cmd/fh3/appdata/export/list.js
+++ b/lib/cmd/fh3/appdata/export/list.js
@@ -21,7 +21,9 @@ module.exports = {
     return 'api/v2/appdata/' + params.envId + '/' + params.appId + '/data/export';
   },
   'postCmd': function(argv, params, cb) {
-    params._table = common.createTableForAppData(params);
+    if (!argv.json) {
+      params._table = common.createTableForAppData(params);
+    }
     return cb(null, params);
   }
 };

--- a/lib/cmd/fh3/appdata/import/list.js
+++ b/lib/cmd/fh3/appdata/import/list.js
@@ -20,7 +20,9 @@ module.exports = {
     return 'api/v2/appdata/' + params.envId + '/' + params.appId + '/data/import';
   },
   'postCmd': function(argv, params, cb) {
-    params._table = common.createTableForAppData(params);
+    if (!argv.json) {
+      params._table = common.createTableForAppData(params);
+    }
     return cb(null, params);
   }
 };

--- a/lib/cmd/fh3/appdata/import/list.js
+++ b/lib/cmd/fh3/appdata/import/list.js
@@ -19,7 +19,7 @@ module.exports = {
   'url': function(params) {
     return 'api/v2/appdata/' + params.envId + '/' + params.appId + '/data/import';
   },
-  'postCmd': function(params, cb) {
+  'postCmd': function(argv, params, cb) {
     params._table = common.createTableForAppData(params);
     return cb(null, params);
   }

--- a/lib/cmd/fh3/appforms/data-sources/create.js
+++ b/lib/cmd/fh3/appforms/data-sources/create.js
@@ -16,7 +16,7 @@ module.exports = {
   },
   'url': "/api/v2/appforms/data_sources",
   'method': 'post',
-  'postCmd': function(dataSource, cb) {
+  'postCmd': function(argv, dataSource, cb) {
     dataSource._table = common.createTableForDataSources(dataSource);
     cb(undefined, dataSource);
   }

--- a/lib/cmd/fh3/appforms/data-sources/create.js
+++ b/lib/cmd/fh3/appforms/data-sources/create.js
@@ -17,7 +17,9 @@ module.exports = {
   'url': "/api/v2/appforms/data_sources",
   'method': 'post',
   'postCmd': function(argv, dataSource, cb) {
-    dataSource._table = common.createTableForDataSources(dataSource);
+    if (!argv.json) {
+      dataSource._table = common.createTableForDataSources(dataSource);
+    }
     cb(undefined, dataSource);
   }
 };

--- a/lib/cmd/fh3/appforms/data-sources/list.js
+++ b/lib/cmd/fh3/appforms/data-sources/list.js
@@ -10,7 +10,9 @@ module.exports = {
   'url': "/api/v2/appforms/data_sources",
   'method': 'get',
   'postCmd': function(argv, dataSources, cb) {
-    dataSources._table = common.createTableForDataSources(dataSources);
+    if (!argv.json) {
+      dataSources._table = common.createTableForDataSources(dataSources);
+    }
     cb(undefined, dataSources);
   }
 };

--- a/lib/cmd/fh3/appforms/data-sources/list.js
+++ b/lib/cmd/fh3/appforms/data-sources/list.js
@@ -9,7 +9,7 @@ module.exports = {
   'describe': {},
   'url': "/api/v2/appforms/data_sources",
   'method': 'get',
-  'postCmd': function(dataSources, cb) {
+  'postCmd': function(argv, dataSources, cb) {
     dataSources._table = common.createTableForDataSources(dataSources);
     cb(undefined, dataSources);
   }

--- a/lib/cmd/fh3/appforms/data-sources/read.js
+++ b/lib/cmd/fh3/appforms/data-sources/read.js
@@ -13,7 +13,7 @@ module.exports = {
     return "/api/v2/appforms/data_sources/" + params.id;
   },
   'method': 'get',
-  'postCmd': function(dataSource, cb) {
+  'postCmd': function(argv, dataSource, cb) {
     dataSource._table = common.createTableForDataSources(dataSource);
     cb(undefined, dataSource);
   }

--- a/lib/cmd/fh3/appforms/data-sources/read.js
+++ b/lib/cmd/fh3/appforms/data-sources/read.js
@@ -14,7 +14,9 @@ module.exports = {
   },
   'method': 'get',
   'postCmd': function(argv, dataSource, cb) {
-    dataSource._table = common.createTableForDataSources(dataSource);
+    if (!argv.json) {
+      dataSource._table = common.createTableForDataSources(dataSource);
+    }
     cb(undefined, dataSource);
   }
 };

--- a/lib/cmd/fh3/appforms/data-sources/update.js
+++ b/lib/cmd/fh3/appforms/data-sources/update.js
@@ -38,7 +38,9 @@ module.exports = {
   },
   'method': 'put',
   'postCmd': function(argv, dataSource, cb) {
-    dataSource._table = common.createTableForDataSources(dataSource);
+    if (!argv.json) {
+      dataSource._table = common.createTableForDataSources(dataSource);
+    }
     cb(undefined, dataSource);
   }
 };

--- a/lib/cmd/fh3/appforms/data-sources/update.js
+++ b/lib/cmd/fh3/appforms/data-sources/update.js
@@ -37,7 +37,7 @@ module.exports = {
     return "/api/v2/appforms/data_sources/" + updateData._id;
   },
   'method': 'put',
-  'postCmd': function(dataSource, cb) {
+  'postCmd': function(argv, dataSource, cb) {
     dataSource._table = common.createTableForDataSources(dataSource);
     cb(undefined, dataSource);
   }

--- a/lib/cmd/fh3/appforms/environments/data-sources/audit-logs.js
+++ b/lib/cmd/fh3/appforms/environments/data-sources/audit-logs.js
@@ -28,10 +28,11 @@ module.exports = {
       return (now - new Date(auditLogEntry.updateTimestamp));
     });
 
-    dataSourceWithAuditLogs._table = common.createTableForEnvDataSourcesAuditLogs(dataSourceWithAuditLogs, {
-      limit: this.limit
-    });
-
+    if (!argv.json) {
+      dataSourceWithAuditLogs._table = common.createTableForEnvDataSourcesAuditLogs(dataSourceWithAuditLogs, {
+        limit: this.limit
+      });
+    }
     cb(undefined, dataSourceWithAuditLogs);
   }
 };

--- a/lib/cmd/fh3/appforms/environments/data-sources/audit-logs.js
+++ b/lib/cmd/fh3/appforms/environments/data-sources/audit-logs.js
@@ -20,7 +20,7 @@ module.exports = {
     this.limit = params.limit;
     cb(undefined, params);
   },
-  'postCmd': function(dataSourceWithAuditLogs, cb) {
+  'postCmd': function(argv, dataSourceWithAuditLogs, cb) {
     var now = new Date();
 
     //Sorting By The Time The Data Source Was Updated

--- a/lib/cmd/fh3/appforms/environments/data-sources/list.js
+++ b/lib/cmd/fh3/appforms/environments/data-sources/list.js
@@ -14,8 +14,9 @@ module.exports = {
   },
   'method' : 'get',
   'postCmd': function(argv, dataSources, cb) {
-    dataSources._table = common.createTableForEnvDataSources(dataSources);
-
+    if (!argv.json) {
+      dataSources._table = common.createTableForEnvDataSources(dataSources);
+    }
     cb(undefined, dataSources);
   }
 

--- a/lib/cmd/fh3/appforms/environments/data-sources/list.js
+++ b/lib/cmd/fh3/appforms/environments/data-sources/list.js
@@ -13,7 +13,7 @@ module.exports = {
     return "/api/v2/mbaas/" + params.environment + "/appforms/data_sources";
   },
   'method' : 'get',
-  'postCmd': function(dataSources, cb) {
+  'postCmd': function(argv, dataSources, cb) {
     dataSources._table = common.createTableForEnvDataSources(dataSources);
 
     cb(undefined, dataSources);

--- a/lib/cmd/fh3/appforms/environments/data-sources/read.js
+++ b/lib/cmd/fh3/appforms/environments/data-sources/read.js
@@ -14,7 +14,7 @@ module.exports = {
     return "/api/v2/mbaas/" + params.environment + "/appforms/data_sources/" + params.id;
   },
   'method' : 'get',
-  'postCmd': function(dataSources, cb) {
+  'postCmd': function(argv, dataSources, cb) {
     dataSources._table = common.createTableForEnvDataSources(dataSources);
 
     cb(undefined, dataSources);

--- a/lib/cmd/fh3/appforms/environments/data-sources/read.js
+++ b/lib/cmd/fh3/appforms/environments/data-sources/read.js
@@ -15,8 +15,9 @@ module.exports = {
   },
   'method' : 'get',
   'postCmd': function(argv, dataSources, cb) {
-    dataSources._table = common.createTableForEnvDataSources(dataSources);
-
+    if (!argv.json) {
+      dataSources._table = common.createTableForEnvDataSources(dataSources);
+    }
     cb(undefined, dataSources);
   }
 };

--- a/lib/cmd/fh3/appforms/environments/data-sources/refresh.js
+++ b/lib/cmd/fh3/appforms/environments/data-sources/refresh.js
@@ -14,7 +14,7 @@ module.exports = {
     return "/api/v2/mbaas/" + params.environment + "/appforms/data_sources/" + params.id + "/refresh";
   },
   'method' : 'post',
-  'postCmd': function(dataSources, cb) {
+  'postCmd': function(argv, dataSources, cb) {
     dataSources._table = common.createTableForEnvDataSources(dataSources);
 
     cb(undefined, dataSources);

--- a/lib/cmd/fh3/appforms/environments/data-sources/refresh.js
+++ b/lib/cmd/fh3/appforms/environments/data-sources/refresh.js
@@ -15,8 +15,9 @@ module.exports = {
   },
   'method' : 'post',
   'postCmd': function(argv, dataSources, cb) {
-    dataSources._table = common.createTableForEnvDataSources(dataSources);
-
+    if (!argv.json) {
+      dataSources._table = common.createTableForEnvDataSources(dataSources);
+    }
     cb(undefined, dataSources);
   }
 };

--- a/lib/cmd/fh3/appforms/environments/data-sources/validate.js
+++ b/lib/cmd/fh3/appforms/environments/data-sources/validate.js
@@ -19,8 +19,9 @@ module.exports = {
   },
   'method': 'post',
   'postCmd': function(argv, dataSources, cb) {
-    dataSources._table = common.createTableForEnvDataSourcesValidation(dataSources);
-
+    if (!argv.json) {
+      dataSources._table = common.createTableForEnvDataSourcesValidation(dataSources);
+    }
     cb(undefined, dataSources);
   }
 };

--- a/lib/cmd/fh3/appforms/environments/data-sources/validate.js
+++ b/lib/cmd/fh3/appforms/environments/data-sources/validate.js
@@ -18,7 +18,7 @@ module.exports = {
     return "/api/v2/mbaas/" + params.environment + "/appforms/data_sources/validate";
   },
   'method': 'post',
-  'postCmd': function(dataSources, cb) {
+  'postCmd': function(argv, dataSources, cb) {
     dataSources._table = common.createTableForEnvDataSourcesValidation(dataSources);
 
     cb(undefined, dataSources);

--- a/lib/cmd/fh3/appforms/environments/submissions/filter.js
+++ b/lib/cmd/fh3/appforms/environments/submissions/filter.js
@@ -28,10 +28,14 @@ module.exports = {
   },
   'postCmd': function(argv, submissionsResult, cb) {
     submissionsResult = submissionsResult || {};
-    var table = common.createTableForSubmissions(submissionsResult);
-    var submissionsArray = submissionsResult.submissions;
-    submissionsArray._table = table;
-    cb(undefined, submissionsArray);
+    if (!argv.json) {
+      var table = common.createTableForSubmissions(submissionsResult);
+      var submissionsArray = submissionsResult.submissions;
+      submissionsArray._table = table;
+      return cb(null, submissionsArray);
+    } else {
+      return cb(null,submissionsResult);
+    }
   },
   'method': 'post'
 };

--- a/lib/cmd/fh3/appforms/environments/submissions/filter.js
+++ b/lib/cmd/fh3/appforms/environments/submissions/filter.js
@@ -26,7 +26,7 @@ module.exports = {
 
     return cb(undefined, _.omit(params, "formid", "projectid"));
   },
-  'postCmd': function(submissionsResult, cb) {
+  'postCmd': function(argv, submissionsResult, cb) {
     submissionsResult = submissionsResult || {};
     var table = common.createTableForSubmissions(submissionsResult);
     var submissionsArray = submissionsResult.submissions;

--- a/lib/cmd/fh3/appforms/environments/submissions/list.js
+++ b/lib/cmd/fh3/appforms/environments/submissions/list.js
@@ -21,9 +21,14 @@ module.exports = {
   'method': 'get',
   'postCmd': function(argv, submissionsResult, cb) {
     submissionsResult = submissionsResult || {};
-    var table = common.createTableForSubmissions(submissionsResult);
-    var submissionsArray = submissionsResult.submissions;
-    submissionsArray._table = table;
-    cb(undefined, submissionsArray);
+    if (!argv.json) {
+      var table = common.createTableForSubmissions(submissionsResult);
+      var submissionsArray = submissionsResult.submissions;
+      submissionsArray._table = table;
+      return cb(undefined, submissionsArray);
+    } else {
+      return cb(null, submissionsResult);
+    }
+
   }
 };

--- a/lib/cmd/fh3/appforms/environments/submissions/list.js
+++ b/lib/cmd/fh3/appforms/environments/submissions/list.js
@@ -19,7 +19,7 @@ module.exports = {
     return "/api/v2/mbaas/" + params.environment + "/appforms/submissions?page=" + params.page + "&limit=" + params.limit;
   },
   'method': 'get',
-  'postCmd': function(submissionsResult, cb) {
+  'postCmd': function(argv, submissionsResult, cb) {
     submissionsResult = submissionsResult || {};
     var table = common.createTableForSubmissions(submissionsResult);
     var submissionsArray = submissionsResult.submissions;

--- a/lib/cmd/fh3/artifacts.js
+++ b/lib/cmd/fh3/artifacts.js
@@ -17,10 +17,13 @@ module.exports = {
     return 'box/srv/1.1/artifacts?isBuild=true&appId=' + argv.app;
   },
   'method' : 'get',
-  'postCmd': function(params, cb) {
-    var headers = ['Platform', 'App Version', 'Date', 'Type', 'Credential', 'Url'];
-    var fields = ['destination', 'appVersion', 'sysModified', 'type', 'credential', 'otaurl'];
-    params._table = common.createTableFromArray(headers, fields, params);
+  'postCmd': function(argv, params, cb) {
+    if (!argv.json) {
+      var headers = ['Platform', 'App Version', 'Date', 'Type', 'Credential', 'Url'];
+      var fields = ['destination', 'appVersion', 'sysModified', 'type', 'credential', 'otaurl'];
+      params._table = common.createTableFromArray(headers, fields, params);
+    }
     return cb(null, params);
+
   }
 };

--- a/lib/cmd/fh3/connections/list.js
+++ b/lib/cmd/fh3/connections/list.js
@@ -20,7 +20,7 @@ module.exports = {
     return "box/api/projects/" + argv.project + '/connections';
   },
   'method' : 'get',
-  'postCmd': function(params, cb) {
+  'postCmd': function(argv, params, cb) {
     var headers = ['Id', 'Environment', 'Connection Tag', 'Platform', 'Client App', 'Cloud App', 'Build Type', 'Status'];
     var fields = ['guid', 'environment', 'tag', 'destination', 'clientApp', 'cloudApp', 'build', 'status'];
     params._table = common.createTableFromArray(headers, fields, params);

--- a/lib/cmd/fh3/connections/list.js
+++ b/lib/cmd/fh3/connections/list.js
@@ -21,9 +21,11 @@ module.exports = {
   },
   'method' : 'get',
   'postCmd': function(argv, params, cb) {
-    var headers = ['Id', 'Environment', 'Connection Tag', 'Platform', 'Client App', 'Cloud App', 'Build Type', 'Status'];
-    var fields = ['guid', 'environment', 'tag', 'destination', 'clientApp', 'cloudApp', 'build', 'status'];
-    params._table = common.createTableFromArray(headers, fields, params);
+    if (!argv.json) {
+      var headers = ['Id', 'Environment', 'Connection Tag', 'Platform', 'Client App', 'Cloud App', 'Build Type', 'Status'];
+      var fields = ['guid', 'environment', 'tag', 'destination', 'clientApp', 'cloudApp', 'build', 'status'];
+      params._table = common.createTableFromArray(headers, fields, params);
+    }
     return cb(null, params);
   }
 };

--- a/lib/cmd/fh3/connections/read.js
+++ b/lib/cmd/fh3/connections/read.js
@@ -30,10 +30,11 @@ module.exports = {
       if (!conn) {
         return cb(i18n._('Connection not found: ') + params.connection);
       }
-
-      var headers = ['Id', 'Environment', 'Connection Tag', 'Platform', 'Client App', 'Cloud App', 'Build Type', 'Status'];
-      var fields = ['guid', 'environment', 'tag', 'destination', 'clientApp', 'cloudApp', 'build', 'status'];
-      params._table = common.createTableFromArray(headers, fields, [conn]);
+      if (!params.json) {
+        var headers = ['Id', 'Environment', 'Connection Tag', 'Platform', 'Client App', 'Cloud App', 'Build Type', 'Status'];
+        var fields = ['guid', 'environment', 'tag', 'destination', 'clientApp', 'cloudApp', 'build', 'status'];
+        params._table = common.createTableFromArray(headers, fields, [conn]);
+      }
       return cb(null, params);
     });
   }

--- a/lib/cmd/fh3/connections/update.js
+++ b/lib/cmd/fh3/connections/update.js
@@ -58,9 +58,11 @@ module.exports = {
         if (response.statusCode !== 200) {
           return cb(raw);
         }
-        var headers = ['Id', 'Environment', 'Connection Tag', 'Platform', 'Client App', 'Cloud App', 'Build Type', 'Status'];
-        var fields = ['guid', 'environment', 'tag', 'destination', 'clientApp', 'cloudApp', 'build', 'status'];
-        params._table = common.createTableFromArray(headers, fields, [con]);
+        if (!params.json) {
+          var headers = ['Id', 'Environment', 'Connection Tag', 'Platform', 'Client App', 'Cloud App', 'Build Type', 'Status'];
+          var fields = ['guid', 'environment', 'tag', 'destination', 'clientApp', 'cloudApp', 'build', 'status'];
+          params._table = common.createTableFromArray(headers, fields, [con]);
+        }
         return cb(null, params);
       });
     });

--- a/lib/cmd/fh3/credential/delete.js
+++ b/lib/cmd/fh3/credential/delete.js
@@ -20,9 +20,10 @@ module.exports = {
   },
   'method' : 'delete',
   'postCmd': function(argv, response, cb) {
-    if (response.status === 'ok') {
+    if (!argv.json && response.status === 'ok') {
       return cb(null, i18n._("Credential bundle deleted successfully"));
+    } else {
+      return cb(null, response);
     }
-    return cb(null, response);
   }
 };

--- a/lib/cmd/fh3/credential/delete.js
+++ b/lib/cmd/fh3/credential/delete.js
@@ -19,7 +19,7 @@ module.exports = {
     return "/box/api/credentials/" + bundleId;
   },
   'method' : 'delete',
-  'postCmd': function(response, cb) {
+  'postCmd': function(argv, response, cb) {
     if (response.status === 'ok') {
       return cb(null, i18n._("Credential bundle deleted successfully"));
     }

--- a/lib/cmd/fh3/services/create.js
+++ b/lib/cmd/fh3/services/create.js
@@ -51,7 +51,7 @@ module.exports = {
       payload.template = template;
       common.createService(payload,cb);
     });
-  },'postCmd': function(params, cb) {
+  },'postCmd': function(argv, params, cb) {
     if (params) {
       return cb(null, util.format(i18n._("Service '%s' create successfully"), params.title));
     }

--- a/lib/cmd/fh3/services/create.js
+++ b/lib/cmd/fh3/services/create.js
@@ -52,8 +52,10 @@ module.exports = {
       common.createService(payload,cb);
     });
   },'postCmd': function(argv, params, cb) {
-    if (params) {
+    if (params && !argv.json) {
       return cb(null, util.format(i18n._("Service '%s' create successfully"), params.title));
+    } else {
+      return cb(null,params);
     }
   }
 };

--- a/lib/cmd/fh3/services/data-sources.js
+++ b/lib/cmd/fh3/services/data-sources.js
@@ -31,7 +31,9 @@ module.exports = {
         if (err) {
           return cb(err);
         }
-        params._table = common.createTableForDataSources(dataSources || [], service);
+        if (!params.json) {
+          params._table = common.createTableForDataSources(dataSources || [], service);
+        }
         cb(null, params);
       });
     });

--- a/lib/cmd/fh3/services/delete.js
+++ b/lib/cmd/fh3/services/delete.js
@@ -20,7 +20,7 @@ module.exports = {
     return "box/api/connectors/" + argv.service ;
   },
   'method' : 'delete',
-  'postCmd': function(params, cb) {
+  'postCmd': function(argv, params, cb) {
     if ( params ) {
       return cb(null, util.format(i18n._("Service '%s' delete successfully"), params.title));
     }

--- a/lib/cmd/fh3/services/delete.js
+++ b/lib/cmd/fh3/services/delete.js
@@ -21,8 +21,10 @@ module.exports = {
   },
   'method' : 'delete',
   'postCmd': function(argv, params, cb) {
-    if ( params ) {
+    if (params && !argv.json) {
       return cb(null, util.format(i18n._("Service '%s' delete successfully"), params.title));
+    } else {
+      return cb(null,params);
     }
   }
 };

--- a/lib/cmd/fh3/services/list.js
+++ b/lib/cmd/fh3/services/list.js
@@ -19,7 +19,9 @@ module.exports = {
   'url' : 'box/api/connectors/',
   'method' : 'get',
   'postCmd' : function(argv, params, cb) {
-    params._table = common.createTableForProjects(params);
+    if (!argv.json) {
+      params._table = common.createTableForProjects(params);
+    }
     return cb(null, params);
   }
 };

--- a/lib/cmd/fh3/services/list.js
+++ b/lib/cmd/fh3/services/list.js
@@ -18,7 +18,7 @@ module.exports = {
   },
   'url' : 'box/api/connectors/',
   'method' : 'get',
-  'postCmd' : function(params,cb) {
+  'postCmd' : function(argv, params, cb) {
     params._table = common.createTableForProjects(params);
     return cb(null, params);
   }

--- a/lib/cmd/fh3/user.js
+++ b/lib/cmd/fh3/user.js
@@ -31,14 +31,16 @@ module.exports = {
     return "box/srv/1.1/ide/" + domain + "/user/read";
   },
   'method' : 'get',
-  'postCmd' : function(response,cb) {
+  'postCmd' : function(argv, response,cb) {
     if (response.status === 'error' && response.msg && response.msg[0] && response.msg[0].indexOf('Operation not permitted') !== -1) {
       return cb(null,  i18n._("Not logged in"));
     } else {
       if (response.permissions) {
         ini.set("perms", response.permissions);
       }
-      response._table = response.userName + " [" + response.email + "]";
+      if (!argv.json) {
+        response._table = response.userName + " [" + response.email + "]";
+      }
     }
     return cb(null, response);
   }

--- a/lib/genericCommand.js
+++ b/lib/genericCommand.js
@@ -85,6 +85,11 @@ module.exports = function(cmd) {
       postCmd = cmd.postCmd,
       series = [];
 
+    // If the command is called as dependecy without argument the default result will be a json
+    if (!argv) {
+      argv = {json:true};
+    }
+
     // Ensure our series always gets the args as the first param in the chain, regardless of if we have a preFn or not
     series.push(function(cb) {
       return cb(null, argv);

--- a/lib/genericCommand.js
+++ b/lib/genericCommand.js
@@ -115,11 +115,10 @@ module.exports = function(cmd) {
     if (typeof postCmd === 'function') {
       // Apply a useful scope in these functions
       var post = function(params, cb) {
-        postCmd.apply(cmd, [params, cb]);
+        postCmd.apply(cmd, [argv, params, cb]);
       };
       series.push(post);
     }
-
     return async.waterfall(series, cb);
   };
 


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/FH-3657

Following the changes.

* Now, all methods that can improve the output of the results in the commands has the argv ( parameters) informed;

* Now, all points in the project which has a table as output are respecting the `json` parameter for commands executed in via command line and as dependence.

How to check it?
- Add the project as dependency of another
- Call a method that returns a table as result and by passing the JSON as a parameter.
Following an example.

```
fhc.services.list({json: true}, function(err, response) {
      console.log(response);
    });
```
The result can't contain the _table at the end of the response. 


 