### PR TITLE
Changed output of call command to be backward compatible with v2 impl…

### DIFF
--- a/lib/cmd/fh3/call.js
+++ b/lib/cmd/fh3/call.js
@@ -40,8 +40,7 @@ module.exports = {
             "statusCode": response.statusCode
           };
         }
-        params.message = raw;
-        return cb(err, params);
+        return cb(err, remoteData);
       }
       return cb(null, {status: 'error', error: remoteData, statusCode: response.statusCode});
     });


### PR DESCRIPTION
…ementation

# Motivation
In some of our testing tools (e.g. app-art) `call` command is used to interact with studio and it expects the output of the command to be in specific format. Recently `call` was [changed](https://issues.jboss.org/browse/FH-3631) to follow V3 standard and format of output was changed as well, which IMO could stay the same.