### PR TITLE
RHMAP-16184 - Command fhc runtimes is with the dev environment fixed

### DIFF
--- a/lib/cmd/fh3/app/runtimes.js
+++ b/lib/cmd/fh3/app/runtimes.js
@@ -6,24 +6,25 @@ module.exports = {
   'desc': i18n._('Check the available runtimes for an app'),
   'examples':
   [{
-    cmd: 'fhc app runtimes --id=<app-id> --domain=<domain>',
-    desc: i18n._('Runtimes <app-id> in domain <domain>')
+    cmd: 'fhc app runtimes --id=<app-id> --env=<environment> --domain=<domain>',
+    desc: i18n._('Runtimes <app-id> from the <environment> in domain <domain>')
   }],
-  'demand': ['id'],
+  'demand': ['id','env'],
   'alias': {
     'id': 'i',
+    'env':'e',
     'domain': 'd',
     0: 'id',
-    1: 'domain'
+    1: 'env',
+    2: 'domain'
   },
   'describe': {
     'id': i18n._('Unique 24 character GUID of the application '),
+    'env'   : i18n._("Unique 24 character GUID of the environment where this cloud application is deployed."),
     'domain': i18n._('The name of the domain from where the app is')
   },
   'url': function(argv) {
-    var domain = argv.domain || ini.get("domain");
-    var appId = argv.id;
-    return "/api/v2/mbaas/" + domain + "/dev/apps/" + appId + "/runtimes";
+    return "/api/v2/mbaas/" + argv.domain + "/" + argv.env +"/apps/" + argv.id + "/runtimes";
   },
   'postCmd': function(response, cb) {
     if (response.code === 200) {
@@ -31,10 +32,11 @@ module.exports = {
       return cb(null, response);
     }
   },
-  preCmd: function(params, cb) {
+  'preCmd': function(params, cb) {
     var request = {
       id: params.id,
-      domain: params.domain || ini.get("domain")
+      domain: params.domain || ini.get("domain"),
+      env: params.env
     };
 
     return cb(null, request);

--- a/lib/cmd/fh3/app/stage.js
+++ b/lib/cmd/fh3/app/stage.js
@@ -163,7 +163,7 @@ function createData(params) {
  */
 function checkRuntimeBeforeDoStage(params,data,cb) {
   var domain = ini.get("domain");
-  fhc.app.runtimes({id: params.app, domain: domain}, function(err, response) {
+  fhc.app.runtimes({id: params.app, env: params.env, domain: domain}, function(err, response) {
     if (err) {
       return cb(i18n._('Not found runtime: ' + err));
     } else if (!response || !response.result || response.result.empty) {

--- a/test/unit/fh3/app/test_runtimes.js
+++ b/test/unit/fh3/app/test_runtimes.js
@@ -6,6 +6,7 @@ module.exports = {
   'test app runtimes command --id': function(done) {
     var params = {
       domain: "testing",
+      env: "eee",
       id: "j7hslnrb257zkr4qzjndoqkl"
     };
 


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RHMAP-16184

The command runtime was with the environment fixed as dev. We catcher this error via the automated tests. 

Following the local test after this fix. 

<img width="568" alt="screen shot 2017-06-14 at 9 04 04 am" src="https://user-images.githubusercontent.com/7708031/27131328-913e4d46-50e0-11e7-9176-19b25f060fcc.png">

** Verify Steps **
- Go to https://testing.zeta.feedhenry.com/
- take any cloud app id
- Run the command `fhc runtimes` for this app and any environment
