### PR TITLE
Custom home directory support

### DIFF
--- a/lib/utils/ini.js
+++ b/lib/utils/ini.js
@@ -5,7 +5,7 @@ var _ = require('underscore'),
   log = require('./log'),
   configDefs = require('./config-defs');
 
-var configFile = path.resolve(process.env.HOME || process.env.USERPROFILE, ".fhcrc");
+var configFile = path.resolve(process.env.FHC_HOME || process.env.HOME || process.env.USERPROFILE, ".fhcrc");
 
 module.exports = {
   store: {},
@@ -126,4 +126,3 @@ module.exports = {
     fs.writeFile(configFile, lines, cb);
   }
 };
-


### PR DESCRIPTION
Sometimes we may not have permission to access the home directory, e.g when running FHC on RHMAP. This will allow users to set a custom directory for configs.

JIRA: https://issues.jboss.org/browse/RHMAP-16644