### PR TITLE
RHMAP-16061 - Update FHC to honour the mask-value options for environ…

### DIFF
--- a/lib/cmd/fh3/env/create.js
+++ b/lib/cmd/fh3/env/create.js
@@ -9,6 +9,9 @@ module.exports = {
     [{
       cmd : 'fhc env create --app=<app> --name=<name> --value=<value> --env=<environment>',
       desc : i18n._("Create a cloud app environment variables for the <app> in the <env> with the <name> and <value>")
+    },{
+      cmd : 'fhc env create --app=<app> --name=<name> --value=<value> --env=<environment> --mask',
+      desc : i18n._("Create a cloud app environment variables for the <app> in the <env> with the <name> and <value> and masked")
     }],
   'demand' : ['app', 'name'],
   'alias' : {
@@ -16,24 +19,29 @@ module.exports = {
     'name': 'n',
     'value': 'v',
     'env': 'e',
+    'mask': 'm',
     'json': 'j',
     0: 'app',
     1: 'name',
     2: 'value',
-    3: 'env',
-    4: 'json'
+    3: 'env'
   },
   'describe' : {
     'app' : i18n._("Unique 24 character GUID of the cloud app."),
     'name': i18n._("Name of the environment variable."),
     'value': i18n._("Value of the environment variable."),
     'env': i18n._("Default value is dev. Environment ID for which you want to create the environment variable."),
+    'mask' : i18n._("Mask the value of this Environment Variable"),
     'json' : i18n._("Output in json format")
   },
   'customCmd' : function(params, cb) {
     var environment = params.env || 'dev';
     var url = "/box/api/apps/" + params.app + "/env/" + environment + "/envvars";
-    var playload = { masked: "false", name: params.name, value: params.value};
+    var masked = false;
+    if ( params.mask ) {
+      masked = true;
+    }
+    var playload = { masked: masked, name: params.name, value: params.value};
     return common.doApiCall(fhreq.getFeedHenryUrl(), url, playload, i18n._("Error creating env var: "), function(err, data) {
       if (err) {
         return cb(err);

--- a/lib/cmd/fh3/env/update.js
+++ b/lib/cmd/fh3/env/update.js
@@ -10,6 +10,10 @@ module.exports = {
     [{
       cmd : 'fhc env update --app=<app> --id=<id> --value=<value> --env=<environment>',
       desc : i18n._("Update the cloud app environment variables with the <id> from the <app> in the <env> with the <name> and <value>")
+    },
+    {
+      cmd : 'fhc env update --app=<app> --id=<id> --mask',
+      desc : i18n._("Update the cloud app environment variables with the <id> from the <app> in the <env> to be masked")
     }],
   'demand' : ['app', 'id'],
   'alias' : {
@@ -17,18 +21,19 @@ module.exports = {
     'id': 'i',
     'value': 'v',
     'env': 'e',
+    'mask': 'm',
     'json': 'j',
     0: 'app',
     1: 'id',
     2: 'value',
-    3: 'env',
-    4: 'json'
+    3: 'env'
   },
   'describe' : {
     'app' : i18n._("Unique 24 character GUID of the cloud app."),
     'id' : i18n._("Unique 24 character GUID of the environment variable."),
     'value': i18n._("Value of the environment variable."),
     'env': i18n._("Default value is dev. Environment ID for which you want to create the environment variable."),
+    'mask' : i18n._("Mask the value of this Environment Variable"),
     'json' : i18n._("Output in json format")
   },
   'customCmd' : function(params,cb) {
@@ -41,6 +46,9 @@ module.exports = {
         return cb(null, util.format(i18n._("Unable to find environment variable for app with id '%s' for the app '%s'"), params.id, params.app));
       }
       var url = "/box/api/apps/" + params.app + "/env/" + params.env + "/envvars/" + params.id;
+      if ( params.mask ) {
+        data.masked = true;
+      }
       data.value = params.value;
       data.name = data.varName;
       common.doPutApiCall(fhreq.getFeedHenryUrl(), url, data, function(err, result) {

--- a/lib/common.js
+++ b/lib/common.js
@@ -614,6 +614,9 @@ exports.createTableForAppEnvVars = function(appEnvVars, envValue) {
       var value = "";
       if (env.varValues &&  env.varValues[envValue]) {
         value = env.varValues[envValue];
+        if ( env.masked ) {
+          value = "*";
+        }
       }
       table.push([env.guid || "n/a", modified, env.varName, value]);
     });

--- a/test/fixtures/env/fixture_env.js
+++ b/test/fixtures/env/fixture_env.js
@@ -24,7 +24,7 @@ var dataList = [{
       "dev": "valorupdate"
     },
     "varName": "Test2",
-    "masked": false,
+    "masked": true,
     "appId": "3ukgif3bygcn54fd4sysnkkc",
     "sysGroupFlags": 65567,
     "sysGroupList": "",
@@ -75,6 +75,7 @@ module.exports = nock('https://apps.feedhenry.com')
   .post('/box/api/apps/1a/env/dev/envvars')
   .reply(200, data)
   .put('/box/api/apps/1a/env/dev/envvars/2b')
+  .times(2)
   .reply(200, data)
   .delete('/box/api/apps/1a/env/dev/envvars/2b')
   .reply(200, {})
@@ -85,7 +86,7 @@ module.exports = nock('https://apps.feedhenry.com')
     "result": null
   })
   .get('/box/api/apps/1a/env/dev/envvars')
-  .times(3)
+  .times(4)
   .reply(200, dataList)
   .put('/box/api/apps/1a/env/dev/envvars/2b/unset')
   .reply(200, data)

--- a/test/unit/fh3/env/test_env.js
+++ b/test/unit/fh3/env/test_env.js
@@ -12,12 +12,14 @@ var envCmd = {
   delete: genericCommand(require('cmd/fh3/env/delete'))
 };
 
+
 module.exports = {
   'test env create --app=<app> --name=<name> --env=<environment> --json': function(cb) {
     envCmd.create({app:'1a', name:'name', env:'dev', json:true}, function(err, data) {
       assert.equal(err, null);
       assert.notEqual(data, null);
       assert.ok(data.status, "ok");
+      assert.equal(data._table, null);
       return cb();
     });
   },
@@ -25,6 +27,7 @@ module.exports = {
     envCmd.delete({app:'1a', id:'2b', env:'dev', json:true}, function(err, data) {
       assert.equal(err, null);
       assert.notEqual(data, null);
+      assert.equal(data._table, null);
       return cb();
     });
   },
@@ -35,6 +38,9 @@ module.exports = {
       assert.equal(table['0'][0], '2b');
       assert.equal(table['0'][2], 'assa');
       assert.equal(table['0'][3], 'test2');
+      assert.equal(table['1'][0], 'nqnbvq2u3lvmu2xnehvmtpca');
+      assert.equal(table['1'][2], 'Test2');
+      assert.equal(table['1'][3], '*');
       return cb();
     });
   },
@@ -56,6 +62,15 @@ module.exports = {
     envCmd.update({app:'1a', id:'2b', value:'value', env:'dev', json:true}, function(err, data) {
       assert.equal(err, null);
       assert.notEqual(data, null);
+      assert.equal(data._table, null);
+      return cb();
+    });
+  },
+  'test fhc env update --app=<app> --id=<id> --mask --json': function(cb) {
+    envCmd.update({app:'1a', id:'2b', mask:true, env:'dev', json:true}, function(err, data) {
+      assert.equal(err, null);
+      assert.notEqual(data, null);
+      assert.equal(data._table, null);
       return cb();
     });
   },
@@ -66,3 +81,5 @@ module.exports = {
     });
   }
 };
+
+


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RHMAP-16061

Feature Request: Update FHC to honor the mask-value options for environment variables

**Steps to Verify**

1. Create a new project
2. Go to the cloud application and take the number of the appid
3. target the domain and perform the login via FHC
4. For this cloud application create an env masked. 
Command : `fhc env create --app=<app> --name=<name> --value=<value> --env=<environment> --mask`
5. List all env of this cloud app. The value should be masked 
Command : `fhc env list --app=<app> --env=<environment>``
6. Create a new env as step 4 without the parameter mask. 
7. List it to check that is not masked as step 5
8. Update thn unmask env to be masked.
Command : `fhc env update --app=<app> --id=<id> --mask`

**Following the local tests** 

<img width="1267" alt="screen shot 2017-07-05 at 4 41 02 pm" src="https://user-images.githubusercontent.com/7708031/27882635-d5172334-61a3-11e7-8084-fa1a2ca2ea45.png">

<img width="834" alt="screen shot 2017-07-05 at 4 41 13 pm" src="https://user-images.githubusercontent.com/7708031/27882642-dade9a36-61a3-11e7-800a-054c635fc9e4.png">

<img width="762" alt="screen shot 2017-07-05 at 4 43 41 pm" src="https://user-images.githubusercontent.com/7708031/27882648-e016cae6-61a3-11e7-9950-5e5b2cab81ce.png">

<img width="842" alt="screen shot 2017-07-05 at 4 44 29 pm" src="https://user-images.githubusercontent.com/7708031/27882657-e45119cc-61a3-11e7-8a89-83fc8fd8e559.png">

<img width="761" alt="screen shot 2017-07-05 at 4 55 50 pm" src="https://user-images.githubusercontent.com/7708031/27882663-e94e6b64-61a3-11e7-9fdd-1171f2ef8b06.png">
