### PR TITLE
FH-3789 - fhc is missing the command resources list command

### DIFF
--- a/lib/cmd/fh3/resources/list.js
+++ b/lib/cmd/fh3/resources/list.js
@@ -1,0 +1,21 @@
+/* globals i18n */
+var fhc = require("../../../fhc");
+
+module.exports = {
+  'desc' : i18n._('List Resources across RHMAP'),
+  'examples' :
+    [{
+      cmd : 'fhc resources list',
+      desc : i18n._('List of all resources of this domain')
+    }],
+  'demand' : ['env'],
+  'alias' : {
+    'env' : 'e',
+    0 : 'env'
+  },
+  'describe' : {},
+  'url' : function(argv) {
+    return "api/v2/resources/" + fhc.curTarget + "/" + argv.env ;
+  },
+  'method' : 'get'
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.18.0-BUILD-NUMBER",
+  "version": "2.18.1-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.18.0
+sonar.projectVersion=2.18.1
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/unit/fh3/resources/test_resources.js
+++ b/test/unit/fh3/resources/test_resources.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 var genericCommand = require('genericCommand');
 var setCmd = genericCommand(require('cmd/fh3/resources/cache/set'));
+var listResourcesCmd = genericCommand(require('cmd/fh3/resources/list'));
 var flushCmd = genericCommand(require('cmd/fh3/resources/cache/flush'));
 
 var nock = require('nock');
@@ -27,6 +28,8 @@ var dataSet = {
 };
 
 module.exports = nock('https://apps.feedhenry.com')
+  .get('/api/v2/resources/apps/dev')
+  .reply(200, {})
   .post('/api/v2/resources/apps/dev/cache/set')
   .reply(200, dataSet);
 
@@ -37,5 +40,12 @@ module.exports = {
       assert.equal(data.state,"RUNNING");
       return cb();
     });
+  },
+  'fhc resources list --env': function(cb) {
+    listResourcesCmd({env:'dev'}, function(err) {
+      assert.equal(err, null);
+      return cb();
+    });
   }
+
 };


### PR DESCRIPTION
This command was not working on the previous version and it is missing the latest one. 
JIRA: https://issues.jboss.org/browse/FH-3789

**Observation**: The rest service called is not working. 
Internal RHMAP JIRA to fix it is https://issues.jboss.org/browse/RHMAP-17007
