### PR TITLE
fhc apps [list] command is not accepting optional word list

### DIFF
--- a/lib/cmd/common/apps.js
+++ b/lib/cmd/common/apps.js
@@ -5,7 +5,7 @@ apps.list = list;
 
 apps.desc = i18n._("Lists applications");
 apps.usage = "\nfhc apps";
-apps.usage_ngui = "\nfhc apps [list] <project-id>" +
+apps.usage_ngui = "\nfhc apps list <project-id>" +
                   "\nfhc apps create <project-id> <app-title> [<template-id>]" +
                   "\nfhc apps create <project-id> <app-title> <template-type> <git-repo> [<git-branch>]" +
                   "\nfhc apps read <project-id> <app-id>" +

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.18.3-BUILD-NUMBER",
+  "version": "2.18.4-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.18.3
+sonar.projectVersion=2.18.4
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RHMAP-16944

Motivation: Just remove the description about the word list be optional.

Following the local test
```
dhcp-17-108:fh-fhc cmacedo$ ./bin/fhc.js apps 
fhc ERR! 
fhc ERR! fhc apps list <project-id>
fhc ERR! fhc apps create <project-id> <app-title> [<template-id>]
fhc ERR! fhc apps create <project-id> <app-title> <template-type> <git-repo> [<git-branch>]
fhc ERR! fhc apps read <project-id> <app-id>
fhc ERR! fhc apps update <project-id> <app-id> <property-name> <property-value>
fhc ERR! fhc apps delete <project-id> <app-id>
fhc Command executed with error
dhcp-17-108:fh-fhc cmacedo$ 
```
