### PR TITLE
RHMAP-17105 - Unable to build via FHC when the parameter download = t…

### DIFF
--- a/lib/cmd/common/build.js
+++ b/lib/cmd/common/build.js
@@ -219,9 +219,7 @@ function doBuild(args, cb) {
                     return cb(err);
                   }
                   if (data) {
-                    buildResults.push({
-                      download: data
-                    });
+                    buildResults.download = data;
                     build.message = build.message + i18n._("\nDownloaded file: ") + data.file;
                   }
                   return cb(err, results);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "2.18.5-BUILD-NUMBER",
+  "version": "2.19.2-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "2.19.1-BUILD-NUMBER",
+  "version": "2.19.2-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=2.19.1
+sonar.projectVersion=2.19.2
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RHMAP-17105 

**Motivation**: Fix the issue faced when the download parameter is used with the value as true. 
The issue is reflection of the PR https://github.com/feedhenry/fh-fhc/pull/392

**Steps to Verify**

Executed : /bin/fhc.js build app=<cliente app id> cloud_app=<cloud app id> environment=dev destination=android download=true project=<project id>
 
** Following the local test**
<img width="1245" alt="screen shot 2017-08-07 at 5 25 55 pm" src="https://user-images.githubusercontent.com/7708031/29036189-4d55f620-7b96-11e7-8b47-656f70d8b0d4.png">

<img width="609" alt="screen shot 2017-08-07 at 5 26 07 pm" src="https://user-images.githubusercontent.com/7708031/29036188-4d52a4ca-7b96-11e7-9956-2d418619859c.png">
