### PR TITLE
FH-3411 - fh-fhc upload app binary does not use proxy setting

### DIFF
--- a/lib/cmd/fh3/credential/create.js
+++ b/lib/cmd/fh3/credential/create.js
@@ -89,6 +89,6 @@ module.exports = {
       });
     }
 
-    fhreq.doRequestWithDataObjectValues(this.url,dataObject, null, util.format(i18n._("Credential bundle '%s' created successfully"), params.name), cb);
+    fhreq.doRequestWithDataObjectValues(this.url,dataObject, null, null, util.format(i18n._("Credential bundle '%s' created successfully"), params.name), cb);
   }
 };

--- a/lib/utils/request.js
+++ b/lib/utils/request.js
@@ -358,97 +358,20 @@ function streamFileUpload(params, cb) {
   requestjs(opts, uploadHandlerFor(null, cb));
 }
 
-
 function uploadFile(url, filepath, fields, contentType, cb) {
-  var boundary = Math.random();
-  var postData = [];
-  var path = require('path');
-  var filename = path.basename(filepath);
-  _.each(fields, function(field, key) {
-    postData.push(new Buffer(EncodeFieldPart(boundary, key, field), 'ascii'));
-  });
-
-  postData.push(new Buffer(EncodeFilePart(boundary, contentType, 'file', filename), 'ascii'));
-
-  var fileReader = fs.createReadStream(filepath, {encoding: 'binary'});
-  var fileContents = '';
-  fileReader.on('data', function(data) {
-    fileContents += data;
-  });
-  fileReader.on('end', function() {
-    postData.push(new Buffer(fileContents, 'binary'));
-    postData.push(new Buffer("\r\n--" + boundary + "--"), 'ascii');
-    doUploadFile(url, postData, boundary, cb);
-  });
-}
-
-// Field encoding
-function EncodeFieldPart(boundary,name,value) {
-  var returnPart = "--" + boundary + "\r\n";
-  returnPart += "Content-Disposition: form-data; name=\"" + name + "\"\r\n\r\n";
-  returnPart += value + "\r\n";
-  return returnPart;
-}
-
-// File encoding
-function EncodeFilePart(boundary,type,name,filename) {
-  var returnPart = "--" + boundary + "\r\n";
-  returnPart += "Content-Disposition: form-data; name=\"" + name + "\"; filename=\"" + filename + "\"\r\n";
-  returnPart += "Content-Type: " + type + "\r\n\r\n";
-  return returnPart;
-}
-
-// do the actual upload
-function doUploadFile(urlpath, postData, boundary, cb) {
-  var platform = '<node 0.4>';
-  var release = '<node 0.4>';
-  var https;
-  try {
-    platform = os.platform();
-    release = os.release();
-  } catch (x) {
-    // ignored, this will fail on node 0.4.x
-  }
-
-  var length = _.reduce(postData, function(sum, post) {
-    return sum + post.length;
-  }, 0);
-  var url = require('url');
-  https = https || require('https');
-  var postOptions = {
-    host: url.parse(getFeedHenryUrl()).hostname,
-    port: '443',
-    path: urlpath,
-    method: 'POST',
-    headers : {
-      'Content-Type' : 'multipart/form-data; boundary=' + boundary,
-      'Content-Length' : length,
-      'Cookie' : "feedhenry=" + fhc.config.get("cookie") + ";",
-      'User-Agent' : "FHC/" + fhc._version + ' ' + platform + '/' + release
-    }
-  };
-
-  var postRequest = https.request(postOptions, function(response) {
-    response.setEncoding('utf8');
-    var data = '';
-    response.on('data', function(chunk) {
-      data = data + chunk;
-    });
-    response.on('end', function() {
-      log.silly(data, 'app import');
-
-      data = JSON.parse(data);
-      return cb(undefined, data);
-    });
-    response.on('error', function(err) {
-      return cb(err);
+  var dataObject = [{
+    name: 'file',
+    'value': fs.createReadStream(filepath)
+  }];
+  _.each(fields, function(value, key) {
+    dataObject.push({
+      name: key,
+      value: value
     });
   });
 
-  _.each(postData, function(post) {
-    postRequest.write(post);
-  });
-  postRequest.end();
+
+  return doRequestWithDataObjectValues(url, dataObject, null, contentType, null, cb);
 }
 
 function getFeedHenryUrl() {
@@ -544,10 +467,11 @@ function getProxy() {
  * @param url
  * @param dataObject - Object {name: name, value: value}
  * @param method - Default is post ( Optional can be null )
+ * @param contentType - Default is null ( Optional can be e.g image/jpeg )
  * @param successMessage - Output if the command finish with success ( Optional can be null )
  * @param cb
  */
-function doRequestWithDataObjectValues(url, dataObject, method, successMessage, cb) {
+function doRequestWithDataObjectValues(url, dataObject, method, contentType, successMessage, cb) {
 
   var fullUrl = urlUtils.resolve(getFeedHenryUrl(), url);
 
@@ -562,6 +486,10 @@ function doRequestWithDataObjectValues(url, dataObject, method, successMessage, 
 
   var form = req.form();
   _.each(dataObject, function(item) {
-    form.append(item.name, item.value);
+    if ( contentType && item.name === 'file') {
+      form.append(item.name, item.value, {contentType: contentType});
+    } else {
+      form.append(item.name, item.value);
+    }
   });
 }


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/FH-3411

**Steps to verify**

```
$ ./bin/fhc.js fhcfg set proxy <proxy>
$ ./bin/fhc.js admin-storeitems uploadbinary 5w477lfgy3jrnovri7gctsb7 android test.txt 
$ ./bin/fhc.js import pxfgryzid25qgz3g3nmgmufc testZip client_advanced_hybrid /Users/cmacedo/Desktop/ios-7.0-2-CordovaApp-src.zip 
```
