### PR TITLE
FH-3851 - Improve output of the boolean results of the tables for con…

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -1025,6 +1025,11 @@ function createTableFromArray(headers, fields, values) {
 
   _.each(values, function(t) {
     var vals = _.map(fields, function(f) {
+      if (t[f] === true) {
+        return i18n._('Yes') ;
+      } else if (t[f] === false) {
+        return i18n._('No') ;
+      }
       return t[f] ? t[f] : '';
     });
     table.push(vals);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "3.0.2-BUILD-NUMBER",
+  "version": "3.0.3-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "3.0.2-BUILD-NUMBER",
+  "version": "3.0.3-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=3.0.2
+sonar.projectVersion=3.0.3
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/unit/fh3/admin/policies/test_policies.js
+++ b/test/unit/fh3/admin/policies/test_policies.js
@@ -101,8 +101,8 @@ module.exports = {
       assert.equal(table['0'][0], 'iu5ig63cnt65jzxlntypuwib');
       assert.equal(table['0'][1], 'FeedHenry');
       assert.equal(table['0'][2], 'FEEDHENRY');
-      assert.equal(table['0'][3], true);
-      assert.equal(table['0'][4], true);
+      assert.equal(table['0'][3], 'Yes');
+      assert.equal(table['0'][4], 'Yes');
       return cb();
     });
   },

--- a/test/unit/fh3/eventalert/test_eventalert.js
+++ b/test/unit/fh3/eventalert/test_eventalert.js
@@ -39,7 +39,7 @@ module.exports = {
       assert.equal(table['0'][0], '4ulbq3zkggc5ttzpydneaphv');
       assert.equal(table['0'][1], 'clone');
       assert.equal(table['0'][2], 'emails@test.com,emails2@test.com');
-      assert.equal(table['0'][3], true);
+      assert.equal(table['0'][3], 'Yes');
       assert.equal(table['0'][4], 'APP_STATE,APP_ENVIRONMENT');
       assert.equal(table['0'][5], 'CRASHED');
       assert.equal(table['0'][6], 'INFO,WARN,ERROR,FATAL');


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/FH-3851

**Motivation**
1. When the value is false and the generic method to create table is used the result in the table is empty and don't make clear the information for the user.
2. The text Yes and No are more intuitive than the boolean values

**Steps to verify**
Use the command `./bin/fhc.js admin policies list` in order to check it.

**Following the local Test**

<img width="832" alt="screen shot 2017-08-13 at 11 43 08 am" src="https://user-images.githubusercontent.com/7708031/29248943-c54fbed8-801c-11e7-912f-44eb14c13cfb.png">
