### PR TITLE
Filtering apps when creating hello_world_project

### DIFF
--- a/lib/cmd/fh3/projects/create.js
+++ b/lib/cmd/fh3/projects/create.js
@@ -1,9 +1,17 @@
 /* globals i18n */
+var _ = require('underscore');
 var common = require("../../../common");
 var ini = require('../../../utils/ini');
 var templates = require('../../common/templates.js');
 var util = require('util');
 
+// Like NGUI, filter out appTemplates which are
+// not 'selected' before calling create
+function filterSelectedApps(template) {
+  var selectedTemplates = _.where(template.appTemplates, {selected: true});
+  template.appTemplates = selectedTemplates;
+  return template;
+}
 
 module.exports = {
   'desc' : i18n._('Create project'),
@@ -50,12 +58,12 @@ module.exports = {
       if (!template) {
         return cb(i18n._('Template not found: ') + params.template);
       }
-      payload.template = template;
+      payload.template = filterSelectedApps(template);
       common.createProject(payload,cb);
     });
   },'postCmd': function(argv, response, cb) {
     if (response && !argv.json) {
-      return cb(null, util.format(i18n._("Project '%s' create successfully"), response.title));
+      return cb(null, util.format(i18n._("Project '%s' created successfully"), response.title));
     }
     return cb(null, response);
   }


### PR DESCRIPTION
### Motivation

Creating hello world project with all apps included (10 apps) is causing an error (in RHMAP 4.x)
```
fhc ERR! Error: Error - not 2xx status code. (504)
fhc ERR! null
fhc ERR!
fhc ERR! System Darwin 16.7.0
fhc ERR! command "node" "/Users/psturc/.nvm/v0.10.42/bin/fhc" "projects" "create" "psturc-test-fhc" "hello_world_project"
fhc Command executed with error
```

This can be fixed by filtering the apps similarly like in the studio (results in 2 apps created)

Putting back the code from https://github.com/feedhenry/fh-fhc/pull/295