### PR TITLE
Rhmap 17444 - "Not 2xx status" when creating hello_world_project via fhc

### DIFF
--- a/lib/cmd/fh3/projects/create.js
+++ b/lib/cmd/fh3/projects/create.js
@@ -3,7 +3,7 @@ var common = require("../../../common");
 var ini = require('../../../utils/ini');
 var util = require('util');
 var fhc = require("../../../fhc");
-
+var _ = require('underscore');
 
 module.exports = {
   'desc' : i18n._('Create project'),
@@ -47,7 +47,7 @@ module.exports = {
       if (err) {
         return cb(err);
       }
-      payload.template = template[0];
+      payload.template = filterSelectedApps(template[0]);
       common.createProject(payload,cb);
     });
   },'postCmd': function(argv, response, cb) {
@@ -58,4 +58,10 @@ module.exports = {
   }
 };
 
-
+// Like NGUI, filter out appTemplates which are
+// not 'selected' before calling create
+function filterSelectedApps(template) {
+  var selectedTemplates = _.where(template.appTemplates, {selected: true});
+  template.appTemplates = selectedTemplates;
+  return template;
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "3.0.6-BUILD-NUMBER",
+  "version": "3.0.7-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "3.0.6-BUILD-NUMBER",
+  "version": "3.0.7-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=3.0.6
+sonar.projectVersion=3.0.7
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/unit/fh3/test_ping.js
+++ b/test/unit/fh3/test_ping.js
@@ -3,19 +3,18 @@ var genericCommand = require('genericCommand');
 var command = genericCommand(require('cmd/fh3/ping'));
 
 var nock = require('nock');
-
 module.exports = nock('https://apps.feedhenry.com')
   .get('/api/v2/mbaas/apps/dev/apps/1a/host')
   .reply(200, {
-    "url": "https://support-k2nqj5yve7jrudhuprei2xzf-dev.mbaas1.us.feedhenry.com"
+    "url": "https://support-1a-dev.mbaas1.us.feedhenry.com"
   })
   .get('/sys/info/ping')
   .reply(200, {});
 
 module.exports = {
   'test ping app': function(cb) {
-    command({app:'1a', env:'dev'}, function(err, data) {
-      assert.equal(err, null);
+    command({app:'1a', env:'dev'}, function(err) {
+      assert.ok(err, null);
       return cb();
     });
   }


### PR DESCRIPTION
Perform the same implementation made into the PR https://github.com/feedhenry/fh-fhc/pull/295/files in order to create the new project with no all client applications select either as it is made by default into NGUI.

JIRA: https://issues.jboss.org/browse/RHMAP-17444

**Local Test:**

```
dhcp-16-185:fh-fhc cmacedo$ ./bin/fhc.js projects create --title=CamilaTest --template=hello_world_project
Project 'CamilaTest' create successfully
```

**Steps to Verify:** 

Create a new project in a domain with the template "hello_world_project".