### PR TITLE
Adding app types help

### DIFF
--- a/lib/cmd/fh3/app/create.js
+++ b/lib/cmd/fh3/app/create.js
@@ -26,7 +26,7 @@ module.exports = {
   },
   'describe': {
     'project': i18n._('Unique 24 character GUID of the project you want this app to be created in.'),
-    'type': i18n._('The type of app.'),
+    'type': i18n._('The type of app. Choose from: \n\t\t - cloud_nodejs (Node.js App) \n\t\t - client_advanced_hybrid (Cordova) \n\t\t - client_native_ios (Native iOS) \n\t\t - client_native_android (Native Android) \n\t\t - webapp_advanced (Web App)\n'),
     'title': i18n._('A title for your app.'),
     'template': i18n._('Template of your app - e.g. hello_world_mbaas_instance. See fhc templates apps.'),
     'repo': i18n._('Repository to clone your app from.'),


### PR DESCRIPTION
Add some help text for app types

`fhc app create --help`

Before:
```
Options:
  --project, -p  Unique 24 character GUID of the project you want this app to be created in.                                                                                                                                               [required]
  --type         The type of app.
```

```
Options:
  --project, -p  Unique 24 character GUID of the project you want this app to be created in.                                                                                                                                               [required]
  --type         The type of app. Choose from:
		 - cloud_nodejs (Node.js App)
		 - client_advanced_hybrid (Cordova)
		 - client_native_ios (Native iOS)
		 - client_native_android (Native Android)
		 - webapp_advanced (Web App)
  [required]
```