### PR TITLE
Moved config.js out of folder and renamed to updateConfig.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.2.2] - Fri Fab 16 2018
+### Changed
+- app/update/config.js moved out of the update folder and renamed to updatedConfig so the command can now be used via: `fhc app updateConfig`.
+
 ## [4.2.1] - Wed Jan 17 2018
 ### Changed
 - updated changelog for fh-fhc version >=2.16.3

--- a/lib/cmd/fh3/app/updateConfig.js
+++ b/lib/cmd/fh3/app/updateConfig.js
@@ -1,6 +1,6 @@
 /* globals i18n */
-var fhreq = require("../../../../utils/request");
-var fhc = require("../../../../fhc");
+var fhreq = require("../../../utils/request");
+var fhc = require("../../../fhc");
 var util = require('util');
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "4.2.1-BUILD-NUMBER",
+  "version": "4.2.2-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/po/fh-fhc.pot
+++ b/po/fh-fhc.pot
@@ -2035,7 +2035,7 @@ msgid ""
 msgstr ""
 
 #: lib/cmd/fh3/app/update.js:30
-#: lib/cmd/fh3/app/update/config.js:25
+#: lib/cmd/fh3/app/updateConfig.js:25
 #: lib/cmd/fh3/connections/list.js:17
 #: lib/cmd/fh3/connections/read.js:22
 #: lib/cmd/fh3/connections/update.js:32
@@ -2047,7 +2047,7 @@ msgid "Unique 24 character GUID of the project"
 msgstr ""
 
 #: lib/cmd/fh3/app/update.js:31
-#: lib/cmd/fh3/app/update/config.js:26
+#: lib/cmd/fh3/app/updateConfig.js:26
 msgid "Unique 24 character GUID of the plaication"
 msgstr ""
 
@@ -2064,33 +2064,33 @@ msgid "Height of the application"
 msgstr ""
 
 #: lib/cmd/fh3/app/update.js:42
-#: lib/cmd/fh3/app/update/config.js:36
+#: lib/cmd/fh3/app/updateConfig.js:36
 msgid "Application '%s' from the project '%' not found"
 msgstr ""
 
-#: lib/cmd/fh3/app/update/config.js:7
+#: lib/cmd/fh3/app/updateConfig.js:7
 msgid "Update config of application"
 msgstr ""
 
-#: lib/cmd/fh3/app/update/config.js:11
+#: lib/cmd/fh3/app/updateConfig.js:11
 msgid ""
 "Update config properties of the <app> via create a new property or by "
 "updating a existing into a domain."
 msgstr ""
 
-#: lib/cmd/fh3/app/update/config.js:27
+#: lib/cmd/fh3/app/updateConfig.js:27
 #: lib/cmd/fh3/projects/update.js:25
 #: lib/cmd/fh3/services/update.js:24
 msgid "Name of the property."
 msgstr ""
 
-#: lib/cmd/fh3/app/update/config.js:28
+#: lib/cmd/fh3/app/updateConfig.js:28
 #: lib/cmd/fh3/projects/update.js:26
 #: lib/cmd/fh3/services/update.js:25
 msgid "Value of the property"
 msgstr ""
 
-#: lib/cmd/fh3/app/update/config.js:42
+#: lib/cmd/fh3/app/updateConfig.js:42
 #: lib/cmd/fh3/build.js:229
 #: lib/common.js:700
 #: lib/common.js:708
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "Error reading app: "
 msgstr ""
 
-#: lib/cmd/fh3/app/update/config.js:47
+#: lib/cmd/fh3/app/updateConfig.js:47
 msgid "Config property set ok"
 msgstr ""
 

--- a/test/unit/fh3/app/test_app.js
+++ b/test/unit/fh3/app/test_app.js
@@ -3,7 +3,7 @@ var genericCommand = require('genericCommand');
 
 var app = {
   update: genericCommand(require('cmd/fh3/app/update')),
-  config: genericCommand(require('cmd/fh3/app/update/config'))
+  updateConfig: genericCommand(require('cmd/fh3/app/updateConfig'))
 };
 
 var nock = require('nock');


### PR DESCRIPTION
This command could not have been used, as the folder where it was places was named `update` and fhc called `update.js` instead.