### PR TITLE
RHMAP-19611 - Adding missing command 'fhc admin appstore storeitems add --id=<id>'

### DIFF
--- a/lib/cmd/fh3/admin/appstore/storeitems/add.js
+++ b/lib/cmd/fh3/admin/appstore/storeitems/add.js
@@ -1,0 +1,33 @@
+/* globals i18n */
+
+var fhreq = require("../../../../../utils/request");
+var common = require("../../../../../common");
+
+module.exports = {
+  'desc' : i18n._('Add Store Item into App Store'),
+  'examples' : [{
+    cmd : 'fhc admin appstore storeitems add --id=<id>',
+    desc : i18n._('Add store item with <id> to the App Store')
+  }],
+  'demand' : ['id'],
+  'alias' : {
+    'id' : 'i',
+    'json' : 'j',
+    0 :'id'
+  },
+  'describe' : {
+    'id' : i18n._("Unique 24 character GUID of the store item."),
+    'json' : i18n._('Output into json format')
+  },
+  'customCmd': function(params, cb) {
+    common.doApiCall(fhreq.getFeedHenryUrl(), "/box/srv/1.1/admin/appstore/additem", {"guid": params.id}, i18n._("Error updating store item: "), function(err,data) {
+      if (err) {
+        return cb(err);
+      }
+      if (!params.json && data.status === "ok") {
+        return cb(null, i18n._('Item Store added successfully.'));
+      }
+      return cb(null, data);
+    });
+  }
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "4.2.1-BUILD-NUMBER",
+  "version": "4.2.3-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "4.2.2-BUILD-NUMBER",
+  "version": "4.2.3-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=4.2.1-BUILD-NUMBER
+sonar.projectVersion=4.2.3-BUILD-NUMBER
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/unit/fh3/admin/appstore/test_storeitems.js
+++ b/test/unit/fh3/admin/appstore/test_storeitems.js
@@ -13,7 +13,8 @@ var commands = {
   delgroups: genericCommand(require('cmd/fh3/admin/appstore/storeitems/delgroups')),
   binaryversions: genericCommand(require('cmd/fh3/admin/appstore/storeitems/binaryversions')),
   grouprestrict: genericCommand(require('cmd/fh3/admin/appstore/storeitems/grouprestrict')),
-  list: genericCommand(require('cmd/fh3/admin/appstore/storeitems/list'))
+  list: genericCommand(require('cmd/fh3/admin/appstore/storeitems/list')),
+  add: genericCommand(require('cmd/fh3/admin/appstore/storeitems/add')),
 };
 
 var nock = require('nock');
@@ -319,7 +320,11 @@ module.exports = nock('https://apps.feedhenry.com')
   .reply(200, {})
   .post('/box/srv/1.1/admin/storeitem/update')
   .times(2)
-  .reply(200, data);
+  .reply(200, data)
+  .post('/box/srv/1.1/admin/appstore/additem')
+  .reply(200, {
+    "status": "ok"
+  });
 
 module.exports = {
   'test fhc admin appstore storeitems create --name=<name> --json': function(cb) {
@@ -446,6 +451,14 @@ module.exports = {
       assert.equal(data._table,null);
       return cb();
     });
-  }
+  },
+  'test fhc admin appstore storeitems add --id --json': function(cb) {
+    commands.add({id:'5w477lfgy3jrnovri7gctsb7',json:true}, function(err, data) {
+      assert.equal(err, null);
+      assert.equal(data._table,null);
+      assert.equal(data.status, "ok");
+      return cb();
+    });
+  },
 
 };


### PR DESCRIPTION
**Motivation**

The command to add a store item[1] related to the point is missing after apply the V3 standard,
 improve the outputs and add the unit tests into the PR [2]. This PR is in order to add the missing command which has the endpoint [3]

**Local tests**

```
camiladeomacedo@Camilas-MBP ~/redhat/fh-fhc (RHMAP-19611) $ ./bin/fhc.js  admin appstore storeitems add --id=3v4qjzyktlnfvevje5unoqgb
Item Store added successfully.
camiladeomacedo@Camilas-MBP ~/redhat/fh-fhc (RHMAP-19611) $ ./bin/fhc.js  admin appstore storeitems add --id=3v4qjzyktlnfvevje5unoqgb --json
{
  "status": "ok"
}
camiladeomacedo@Camilas-MBP ~/redhat/fh-fhc (RHMAP-19611) $ 
```

[1] - https://github.com/feedhenry/fh-fhc/commit/9ae4cc6f4f1007cf19a0829903ecd29e3bf9b5f9#diff-bb7c1835b9d57a46ca5f53d0201d08ebL84
[2] - https://github.com/feedhenry/fh-fhc/pull/378
[3] - https://access.redhat.com/documentation/en-us/red_hat_mobile_application_platform_hosted/3/html/platform_api/mobile-app-management-api#mobile-app-management-api-add-storeitem-to-app-store-admin


