### PR TITLE
RHMAP-19710 - The command "fhc keys user add <label>" is missing in the latest version of FHC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.2.6] - Wed Feb 27 2018
+### Added
+- Came back the command "fhc keys user add <label>" which was missing.
+- Add unit tests for the command "fhc keys user add <label>"
+
 ## [4.2.5] - Wed Feb 21 2018
 ### Changed
 - Updated README to include Tags/Versions to install information

--- a/lib/cmd/fh3/keys/user/add.js
+++ b/lib/cmd/fh3/keys/user/add.js
@@ -1,0 +1,47 @@
+/* globals i18n */
+var common = require('../../../../common.js');
+var fhreq = require("../../../../utils/request");
+var fhc = require("../../../../fhc");
+
+var headers = ["Label", "Key"];
+var fields = ["label", "key"];
+
+
+module.exports = {
+  'desc' : i18n._('Add a user API Key'),
+  'examples' :
+    [{
+      cmd : 'fhc keys user add --label=<label>',
+      desc : i18n._("Add the a new suer key with the <label>")
+    }],
+  'demand' : ['label'],
+  'alias' : {
+    'label': 'l',
+    'json': 'j',
+    0 : 'label'
+  },
+  'describe' : {
+    'label' : i18n._("Label of the API Key that you want to add."),
+    'json' : i18n._("Output in json format")
+  },
+  'customCmd': function(params, cb) {
+    var url = "box/srv/1.1/ide/" + fhc.curTarget + "/api/create";
+    var payload = {
+      "type":"user",
+      "label": params.label,
+      "fields": {
+        "label": params.label
+      }
+    };
+    common.doApiCall(fhreq.getFeedHenryUrl(), url, payload,  i18n._("Error add Api Key: "), function(err, key) {
+      if (err) {
+        return cb(err);
+      }
+      if (!params.json) {
+        params._table = common.createTableFromArray(headers, fields, [key.apiKey]);
+        return cb(null, params);
+      }
+      return cb(null, key);
+    });
+  }
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "4.2.5-BUILD-NUMBER",
+  "version": "4.2.6-BUILD-NUMBER",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "4.2.5-BUILD-NUMBER",
+  "version": "4.2.6-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-fhc
 sonar.projectName=fh-fhc-nightly-master
-sonar.projectVersion=4.2.5-BUILD-NUMBER
+sonar.projectVersion=4.2.6-BUILD-NUMBER
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/unit/fh3/keys/user/test_user.js
+++ b/test/unit/fh3/keys/user/test_user.js
@@ -6,7 +6,8 @@ var userCommand = {
   delete: genericCommand(require('cmd/fh3/keys/user/delete')),
   update: genericCommand(require('cmd/fh3/keys/user/update')),
   read: genericCommand(require('cmd/fh3/keys/user/read')),
-  target: genericCommand(require('cmd/fh3/keys/user/target'))
+  target: genericCommand(require('cmd/fh3/keys/user/target')),
+  add: genericCommand(require('cmd/fh3/keys/user/add'))
 };
 
 var nock = require('nock');
@@ -42,6 +43,9 @@ module.exports = nock('https://apps.feedhenry.com')
   .times(9)
   .reply(200, userList)
   .post('/box/srv/1.1/ide/apps/api/delete')
+  .times(2)
+  .reply(200, key)
+  .post('/box/srv/1.1/ide/apps/api/create')
   .times(2)
   .reply(200, key)
   .post('/box/srv/1.1/ide/apps/api/update')
@@ -123,6 +127,25 @@ module.exports = {
   },
   'fhc keys user delete --label --json' : function(cb) {
     userCommand.delete({label:"FH_MBAAS_API_KEY", json:true}, function(err, data) {
+      assert.equal(err, null);
+      assert.ok(data);
+      assert.equal(data._table, null);
+      assert.equal(data.status, "ok");
+      return cb();
+    });
+  },
+  'fhc keys user add --label' : function(cb) {
+    userCommand.add({label:"FH_MBAAS_API_KEY"}, function(err, data) {
+      assert.equal(err, null);
+      assert.ok(data);
+      var table = data._table;
+      assert.equal(table['0'][0], 'FH_MBAAS_API_KEY');
+      assert.equal(table['0'][1], 'ad351414f0769fdf443203e8ed07534711457f5d');
+      return cb();
+    });
+  },
+  'fhc keys user add --label --json' : function(cb) {
+    userCommand.add({label:"FH_MBAAS_API_KEY", json:true}, function(err, data) {
       assert.equal(err, null);
       assert.ok(data);
       assert.equal(data._table, null);


### PR DESCRIPTION
*Motivation* 

The command "fhc keys user add <label>" is missing in the latest version of FHC.

* Ref.: https://github.com/feedhenry/fh-fhc/pull/376/files#diff-e7ea873a0f36f8c16cdeac0455853567L6
* Documentation : https://access.redhat.com/documentation/en-us/red_hat_mobile_application_platform_hosted/3/html/local_development_guide/local-development-guide-working-with-the-platform-using-fhc#managing-api-keys-with-fhc

*Local Test* 
```

cmacedo@camilas-MacBook-Pro ~/work/fh-fhc (RHMAP-19710) $ ./bin/fhc.js keys user add test --json
{
  "apiKey": {
    "key": "4a2341a65c709e5fa4a1a901dda21b0a88b0ec9e",
    "keyReference": "i4ze7ruomd27wnohth22to4v",
    "keyType": "user",
    "label": "test",
    "revoked": null,
    "revokedBy": null,
    "revokedEmail": null
  },
  "status": "ok"
}
cmacedo@camilas-MacBook-Pro ~/work/fh-fhc (RHMAP-19710) $ ./bin/fhc.js keys user add test 
┌───────┬──────────────────────────────────────────┐
│ Label │ Key                                      │
├───────┼──────────────────────────────────────────┤
│ test  │ 41433c8af00b0337a312195d151e9246a1d4df4a │
└───────┴──────────────────────────────────────────┘

cmacedo@camilas-MacBook-Pro ~/work/fh-fhc (RHMAP-19710) $ 
```