### PR TITLE
fix(RHMAP-20967): Unable to create alerts via fhc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 # Unreleased
 
+## [6.0.1] - Tue Jul 17 2018
+### FiX
+- Fix success output when a alert is created for in a decoupled MBaaS
+
 ## [6.0.0] - Tue Jul 17 2018
 ### FiX
 - Fix fhc help commands

--- a/lib/cmd/fh3/eventalert/create.js
+++ b/lib/cmd/fh3/eventalert/create.js
@@ -43,7 +43,7 @@ module.exports = {
       alertName: argv.name,
       emails: argv.emails,
       enabled: true,
-      env: argv.env,
+      env:argv.env,
       eventCategories: argv.categories,
       eventNames: argv.events,
       eventSeverities: argv.severities,
@@ -54,9 +54,12 @@ module.exports = {
       if (err) {
         return cb(err);
       }
-      if (!argv.json && data && data.status === "ok") {
+      if (!argv.json && data && data.status === "ok") { // Valid just for 3.X
         data._table = common.createTableForEventAlert([data]);
         return cb(null, data);
+      }
+      if (!argv.json) { // 4.X and decoupled MBaaS
+        return cb(null, i18n._("Alert created with success."));
       }
       return cb(null, data);
     });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "6.0.0-BUILD-NUMBER",
+  "version": "6.0.1-BUILD-NUMBER",
   "dependencies": {
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "6.0.0-BUILD-NUMBER",
+  "version": "6.0.1-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"


### PR DESCRIPTION
# Jira:
https://issues.jboss.org/browse/RHMAP-20967

# What:
* Fix success output when an alert is created for in a decoupled MBaaS

# Why:
* All decoupled MBaaS will return an empty body.
* 4.X use just decoupled MBaaS

# How:
If it came back a data show a table if not shows that was created with success. 

# Steps to check:

1. Run `./bin/fhc.js target <domain>` ( e.g ` bin/fhc.js target https://rhmap.osm1.skunkhenry.com/`)
2. Run `./bin/fhc.js login`
3. Run `./bin/fhc eventalert create --app=<app> --name=<name> --categories=<categories>
 --severities=<severities> --events=<events> --emails=<emails> --env=<env>`  ( E.g `./bin/fhc.js eventalert create --app=r6ghddievqzumnsq2djvtruv --name=test --categories=APP_ENVIRONMENT --severities=INFO --events=CHANGE_REQUESTED --emails=test --env=dev` ) 


## Local test

``` javascript
$ ./bin/fhc.js eventalert create --app=r6ghddievqzumnsq2djvtruv --name=test --categories=APP_ENVIRONMENT --severities=INFO --events=CHANGE_REQUESTED --emails=test --env=dev 

Alert created with success.
cmacedo@camilas-MacBook-Pro ~/work/fh-fhc (RHMAP-20967) $ 
```
