### PR TITLE
task(remove windows feat): RHMAP-21057 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 # Unreleased
 
+## [7.0.0] - Tue Jul 17 2018
+### Change
+- Remove Windows features support since them are not so long supported in RHMAP studio.
+
 ## [6.0.1] - Tue Jul 17 2018
 ### FiX
 - Fix success output when a alert is created for in a decoupled MBaaS

--- a/lib/cmd/fh3/build.js
+++ b/lib/cmd/fh3/build.js
@@ -49,7 +49,7 @@ module.exports = {
     'cloud_app' : i18n._("Unique 24 character GUID of the cloud app which the client app will connect to."),
     'tag' : i18n._("The name of a connection tag for the cloud app, must be in Semantic Version format, e.g. 0.0.1. See: http://semver.org."),
     'environment' : i18n._("The id of a target environment, e.g. dev."),
-    'destination' : i18n._("One of: android, iphone, ipad, ios(for universal binary), blackberry, windowsphone7, windowsphone (windows phone 8)."),
+    'destination' : i18n._("One of: android, iphone, ipad, ios(for universal binary), blackberry"),
     'version' : i18n._("Specific to the destination (e.g. Android version 4.0)."),
     'config' : i18n._("Either 'debug' (default), 'distribution', or 'release'."),
     'privateKeyPass' : i18n._("Private key password of the bundleId, only needed for 'release' builds."),

--- a/lib/cmd/fh3/ups/variant/add.js
+++ b/lib/cmd/fh3/ups/variant/add.js
@@ -15,10 +15,6 @@ module.exports = {
     {
       cmd : 'fhc ups variant add --app=<appId> --name=<name> --type=ios --production=<true|false> --passphrase=<passphrase> --certificate=<certificate>',
       desc : i18n._("Add Android variant for the <appId> with the <name>, and <production> and <passphrase>")
-    },
-    {
-      cmd : 'fhc ups variant add --app=<appId> --name=<name> --type=windowns --package=<package> --secret=<secret>',
-      desc : i18n._("Add Android variant for the <appId> with the <name>, and <production> and <passphrase>")
     }],
   'demand' : ['app','name','type'],
   'alias' : {
@@ -40,31 +36,23 @@ module.exports = {
   'describe' : {
     'app' : i18n._("Unique 24 character GUID of your application."),
     'name' : i18n._("Name of the variant."),
-    'type' : i18n._("Type of the variant. Choose from: \n\t\t - android \n\t\t - ios \n\t\t - windows (WNS)\n "),
+    'type' : i18n._("Type of the variant. Choose from: \n\t\t - android \n\t\t - ios \n "),
     'serverKey' : i18n._("Server Key to use Android Firebase Cloud Messaging (E.g. AIza5a448c2f31700a466fbc9d33d33942b043a27596)"),
     'senderId' : i18n._("Sender ID to use Android Firebase Cloud Messaging (E.g.contact@email.com)"),
     'production' : i18n._("To inform if is a production certificate to use the Apple Push Network. Default value is false."),
     'passphrase' : i18n._("Password of the certificate  to use the Apple Push Network"),
     'certificate' : i18n._("Path with the name of the iOS certificate file, *.p12, to use the Apple Push Network."),
-    'package' : i18n._("Package SID to use the Microsoft Push Notification Service (MPNS). (E.g ms-app://s-1-15-2-3183935804-3637592178)"),
-    'secret' : i18n._("Client Secret  to use the Microsoft Push Notification Service (MPNS)."),
     'json' : i18n._("Output in json format")
   },
   'preCmd': function(params, cb) {
     params.type = params.type.toLowerCase();
-    if (params.type !== 'android' && params.type !== 'windowns' && params.type !== 'ios' ) {
+    if (params.type !== 'android' && params.type !== 'ios' ) {
       return cb(i18n._("Invalid type param."));
     }
     switch (params.type) {
     case "ios":
       if (!hasRequiredIosParams(params)) {
         return cb(i18n._("Inform all required parameters to create an iOS variant."));
-      }
-      break;
-    case "windows":
-      params.type = "windows_wns";
-      if (!hasRequiredWinParams(params)) {
-        return cb(i18n._("Inform all required parameters to create an Win variant."));
       }
       break;
     default:
@@ -87,9 +75,6 @@ module.exports = {
     switch (params.type) {
     case "ios":
       playload = createIosPlayload(playload, params);
-      break;
-    case "windows":
-      playload = createWinPlayload(playload, params);
       break;
     default:
       playload = createAndroidPlayload(playload, params);
@@ -165,31 +150,6 @@ function createAndroidPlayload(playload,params) {
  */
 function hasRequiredAndroidParams(params) {
   if ( !params.serverKey || !params.senderId) {
-    return false;
-  }
-  return true;
-}
-
-/**
- * Create the playload for Windows platform variant
- * @param playload
- * @param params
- * @returns {*}
- */
-function createWinPlayload(playload,params) {
-  playload.clientSecret = params.secret;
-  playload.sid = params.package;
-  playload.protocolType = 'wns';
-  return playload;
-}
-
-/**
- * Check if has all requirements to create an Windows variant
- * @param params
- * @returns {boolean}
- */
-function hasRequiredWinParams(params) {
-  if ( !params.package || !params.secret) {
     return false;
   }
   return true;

--- a/lib/cmd/fh3/ups/variant/delete.js
+++ b/lib/cmd/fh3/ups/variant/delete.js
@@ -21,7 +21,7 @@ module.exports = {
   'describe' : {
     'app' : i18n._("Unique 24 character GUID of your application."),
     'id' : i18n._("Variant ID which should be removed. To get this value use $fhc ups variant list --app=<app>"),
-    'type' : i18n._("Type of the variant. Choose from: \n\t\t - android \n\t\t - ios \n\t\t - windows (WNS)\n "),
+    'type' : i18n._("Type of the variant. Choose from: \n\t\t - android \n\t\t - ios \n "),
     'json' : i18n._("Output in json format")
   },
   'preCmd': function(params, cb) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "6.0.1-BUILD-NUMBER",
+  "version": "7.0.0-BUILD-NUMBER",
   "dependencies": {
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "6.0.1-BUILD-NUMBER",
+  "version": "7.0.0-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/po/fh-fhc.pot
+++ b/po/fh-fhc.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2018-05-18 07:58+0000\n"
+"POT-Creation-Date: 2018-07-30 19:46+0000\n"
 
 #: lib/cmd/fh3/-v.js:5
 msgid "Version info about this tool"
@@ -154,8 +154,8 @@ msgstr ""
 #: lib/cmd/fh3/env/unset.js:24
 #: lib/cmd/fh3/env/update.js:37
 #: lib/cmd/fh3/eventalert/clone.js:26
-#: lib/cmd/fh3/eventalert/create.js:36
-#: lib/cmd/fh3/eventalert/list.js:21
+#: lib/cmd/fh3/eventalert/create.js:37
+#: lib/cmd/fh3/eventalert/list.js:22
 #: lib/cmd/fh3/eventalert/update.js:40
 #: lib/cmd/fh3/keys/ssh/add.js:24
 #: lib/cmd/fh3/keys/ssh/delete.js:21
@@ -175,7 +175,7 @@ msgstr ""
 #: lib/cmd/fh3/ups/read.js:20
 #: lib/cmd/fh3/ups/reset.js:19
 #: lib/cmd/fh3/ups/send.js:27
-#: lib/cmd/fh3/ups/variant/add.js:51
+#: lib/cmd/fh3/ups/variant/add.js:45
 #: lib/cmd/fh3/ups/variant/delete.js:25
 #: lib/cmd/fh3/ups/variant/list.js:20
 msgid "Output in json format"
@@ -1779,7 +1779,7 @@ msgstr ""
 #: lib/cmd/fh3/ups/read.js:19
 #: lib/cmd/fh3/ups/reset.js:18
 #: lib/cmd/fh3/ups/send.js:24
-#: lib/cmd/fh3/ups/variant/add.js:41
+#: lib/cmd/fh3/ups/variant/add.js:37
 #: lib/cmd/fh3/ups/variant/delete.js:22
 #: lib/cmd/fh3/ups/variant/list.js:19
 msgid "Unique 24 character GUID of your application."
@@ -3099,9 +3099,7 @@ msgid "The id of a target environment, e.g. dev."
 msgstr ""
 
 #: lib/cmd/fh3/build.js:52
-msgid ""
-"One of: android, iphone, ipad, ios(for universal binary), blackberry, "
-"windowsphone7, windowsphone (windows phone 8)."
+msgid "One of: android, iphone, ipad, ios(for universal binary), blackberry"
 msgstr ""
 
 #: lib/cmd/fh3/build.js:53
@@ -3578,9 +3576,9 @@ msgid "Clone alert with <id> from <app> into <environment> with <name>"
 msgstr ""
 
 #: lib/cmd/fh3/eventalert/clone.js:22
-#: lib/cmd/fh3/eventalert/create.js:29
-#: lib/cmd/fh3/eventalert/delete.js:20
-#: lib/cmd/fh3/eventalert/list.js:19
+#: lib/cmd/fh3/eventalert/create.js:30
+#: lib/cmd/fh3/eventalert/delete.js:21
+#: lib/cmd/fh3/eventalert/list.js:20
 #: lib/cmd/fh3/eventalert/read.js:22
 #: lib/cmd/fh3/eventalert/update.js:32
 #: lib/cmd/fh3/notifications/list.js:23
@@ -3589,22 +3587,22 @@ msgid "Unique 24 character GUID of your cloud application."
 msgstr ""
 
 #: lib/cmd/fh3/eventalert/clone.js:23
-#: lib/cmd/fh3/eventalert/delete.js:21
+#: lib/cmd/fh3/eventalert/delete.js:22
 #: lib/cmd/fh3/eventalert/read.js:23
 #: lib/cmd/fh3/eventalert/update.js:33
 msgid "Unique 24 character GUID of the event alert"
 msgstr ""
 
 #: lib/cmd/fh3/eventalert/clone.js:24
-#: lib/cmd/fh3/eventalert/create.js:30
+#: lib/cmd/fh3/eventalert/create.js:31
 #: lib/cmd/fh3/eventalert/update.js:34
 msgid "Name of the event alert"
 msgstr ""
 
 #: lib/cmd/fh3/eventalert/clone.js:25
-#: lib/cmd/fh3/eventalert/create.js:35
-#: lib/cmd/fh3/eventalert/delete.js:22
-#: lib/cmd/fh3/eventalert/list.js:20
+#: lib/cmd/fh3/eventalert/create.js:36
+#: lib/cmd/fh3/eventalert/delete.js:23
+#: lib/cmd/fh3/eventalert/list.js:21
 #: lib/cmd/fh3/eventalert/read.js:24
 #: lib/cmd/fh3/eventalert/update.js:39
 msgid ""
@@ -3618,61 +3616,65 @@ msgstr ""
 msgid "Alert not found with GUID: "
 msgstr ""
 
-#: lib/cmd/fh3/eventalert/create.js:6
+#: lib/cmd/fh3/eventalert/create.js:7
 msgid "Create event alert for a cloud application"
 msgstr ""
 
-#: lib/cmd/fh3/eventalert/create.js:9
+#: lib/cmd/fh3/eventalert/create.js:10
 msgid ""
 "Create event alert for <app> into <environment> with <name>, for "
 "<categories>, with <severities>, for <events> be sent to <emails>"
 msgstr ""
 
-#: lib/cmd/fh3/eventalert/create.js:31
+#: lib/cmd/fh3/eventalert/create.js:32
 #: lib/cmd/fh3/eventalert/update.js:35
 msgid "Categories of this alert. (E.g APP_STATE,APP_ENVIRONMENT"
 msgstr ""
 
-#: lib/cmd/fh3/eventalert/create.js:32
+#: lib/cmd/fh3/eventalert/create.js:33
 #: lib/cmd/fh3/eventalert/update.js:36
 msgid "Severities of this alert. (E.g INFO,WARN,ERROR,FATAL"
 msgstr ""
 
-#: lib/cmd/fh3/eventalert/create.js:33
+#: lib/cmd/fh3/eventalert/create.js:34
 #: lib/cmd/fh3/eventalert/update.js:37
 msgid "Severities of this alert. (E.g START_REQUESTED,DEPLOY_REQUESTED"
 msgstr ""
 
-#: lib/cmd/fh3/eventalert/create.js:34
+#: lib/cmd/fh3/eventalert/create.js:35
 #: lib/cmd/fh3/eventalert/update.js:38
 msgid "Emails which will received this alert. (E.g test@test.com, test2@test.com"
 msgstr ""
 
-#: lib/cmd/fh3/eventalert/create.js:52
+#: lib/cmd/fh3/eventalert/create.js:53
 msgid "Error to create: "
 msgstr ""
 
-#: lib/cmd/fh3/eventalert/delete.js:5
+#: lib/cmd/fh3/eventalert/create.js:62
+msgid "Alert created with success."
+msgstr ""
+
+#: lib/cmd/fh3/eventalert/delete.js:6
 msgid "Delete alerts from cloud application"
 msgstr ""
 
-#: lib/cmd/fh3/eventalert/delete.js:8
+#: lib/cmd/fh3/eventalert/delete.js:9
 msgid "Delete alert <id> from <app> into <environment>"
 msgstr ""
 
-#: lib/cmd/fh3/eventalert/delete.js:33
+#: lib/cmd/fh3/eventalert/delete.js:34
 msgid "Event alerts with ID '%s' for app '%s' into env '%s' deleted successfully."
 msgstr ""
 
-#: lib/cmd/fh3/eventalert/list.js:6
+#: lib/cmd/fh3/eventalert/list.js:7
 msgid "List of all event alerts from a cloud application"
 msgstr ""
 
-#: lib/cmd/fh3/eventalert/list.js:9
+#: lib/cmd/fh3/eventalert/list.js:10
 msgid "List all event alerts from <app> into <environment>"
 msgstr ""
 
-#: lib/cmd/fh3/eventalert/list.js:32
+#: lib/cmd/fh3/eventalert/list.js:33
 msgid "Alerts not found from app '%s' into env '%s'."
 msgstr ""
 
@@ -4520,83 +4522,67 @@ msgid ""
 msgstr ""
 
 #: lib/cmd/fh3/ups/variant/add.js:17
-#: lib/cmd/fh3/ups/variant/add.js:21
 msgid ""
 "Add Android variant for the <appId> with the <name>, and <production> and "
 "<passphrase>"
 msgstr ""
 
-#: lib/cmd/fh3/ups/variant/add.js:42
+#: lib/cmd/fh3/ups/variant/add.js:38
 msgid "Name of the variant."
 msgstr ""
 
-#: lib/cmd/fh3/ups/variant/add.js:43
+#: lib/cmd/fh3/ups/variant/add.js:39
 #: lib/cmd/fh3/ups/variant/delete.js:24
 msgid ""
 "Type of the variant. Choose from: \n"
 "\t\t - android \n"
 "\t\t - ios \n"
-"\t\t - windows (WNS)\n"
 " "
 msgstr ""
 
-#: lib/cmd/fh3/ups/variant/add.js:44
+#: lib/cmd/fh3/ups/variant/add.js:40
 msgid ""
 "Server Key to use Android Firebase Cloud Messaging (E.g. "
 "AIza5a448c2f31700a466fbc9d33d33942b043a27596)"
 msgstr ""
 
-#: lib/cmd/fh3/ups/variant/add.js:45
+#: lib/cmd/fh3/ups/variant/add.js:41
 msgid "Sender ID to use Android Firebase Cloud Messaging (E.g.contact@email.com)"
 msgstr ""
 
-#: lib/cmd/fh3/ups/variant/add.js:46
+#: lib/cmd/fh3/ups/variant/add.js:42
 msgid ""
 "To inform if is a production certificate to use the Apple Push Network. "
 "Default value is false."
 msgstr ""
 
-#: lib/cmd/fh3/ups/variant/add.js:47
+#: lib/cmd/fh3/ups/variant/add.js:43
 msgid "Password of the certificate  to use the Apple Push Network"
 msgstr ""
 
-#: lib/cmd/fh3/ups/variant/add.js:48
+#: lib/cmd/fh3/ups/variant/add.js:44
 msgid ""
 "Path with the name of the iOS certificate file, *.p12, to use the Apple "
 "Push Network."
 msgstr ""
 
-#: lib/cmd/fh3/ups/variant/add.js:49
-msgid ""
-"Package SID to use the Microsoft Push Notification Service (MPNS). (E.g "
-"ms-app://s-1-15-2-3183935804-3637592178)"
-msgstr ""
-
 #: lib/cmd/fh3/ups/variant/add.js:50
-msgid "Client Secret  to use the Microsoft Push Notification Service (MPNS)."
-msgstr ""
-
-#: lib/cmd/fh3/ups/variant/add.js:56
 msgid "Invalid type param."
 msgstr ""
 
-#: lib/cmd/fh3/ups/variant/add.js:61
+#: lib/cmd/fh3/ups/variant/add.js:55
 msgid "Inform all required parameters to create an iOS variant."
 msgstr ""
 
-#: lib/cmd/fh3/ups/variant/add.js:67
-msgid "Inform all required parameters to create an Win variant."
-msgstr ""
-
-#: lib/cmd/fh3/ups/variant/add.js:72
+#: lib/cmd/fh3/ups/variant/add.js:60
 msgid "Inform all required parameters to create an Android variant."
 msgstr ""
 
-#: lib/cmd/fh3/ups/variant/add.js:99
+#: lib/cmd/fh3/ups/variant/add.js:84
 msgid "Variant '%s' created successfully"
 msgstr ""
 
-#: lib/cmd/fh3/ups/variant/add.js:101
+#: lib/cmd/fh3/ups/variant/add.js:86
 msgid "Error to add variant: "
 msgstr ""
 
@@ -4676,75 +4662,75 @@ msgstr ""
 msgid "no key provided"
 msgstr ""
 
-#: lib/cmd/fhc/help.js:11
+#: lib/cmd/fhc/help.js:8
 msgid "Help with the FeedHenry Command"
 msgstr ""
 
-#: lib/cmd/fhc/help.js:13
+#: lib/cmd/fhc/help.js:10
 msgid "Retrieves help for all of FHC"
 msgstr ""
 
-#: lib/cmd/fhc/help.js:14
+#: lib/cmd/fhc/help.js:11
 msgid "Retrieves help with the app command"
 msgstr ""
 
-#: lib/cmd/fhc/help.js:20
+#: lib/cmd/fhc/help.js:17
 msgid ""
 "Forces the return of JSON output even if config is set otherwise - useful "
 "in scripts"
 msgstr ""
 
-#: lib/cmd/fhc/help.js:23
+#: lib/cmd/fhc/help.js:20
 msgid "Forces the return of table output even if config is set otherwise"
 msgstr ""
 
-#: lib/cmd/fhc/help.js:45
+#: lib/cmd/fhc/help.js:42
 msgid "Error - command not found: "
 msgstr ""
 
-#: lib/cmd/fhc/help.js:69
+#: lib/cmd/fhc/help.js:63
 msgid "FeedHenry CLI, the Command Line Interface to FeedHenry."
 msgstr ""
 
-#: lib/cmd/fhc/help.js:70
+#: lib/cmd/fhc/help.js:64
 msgid ""
 "\n"
 "Usage: fhc <command>"
 msgstr ""
 
-#: lib/cmd/fhc/help.js:72
+#: lib/cmd/fhc/help.js:66
 msgid "where <command> is one of: "
 msgstr ""
 
-#: lib/cmd/fhc/help.js:74
+#: lib/cmd/fhc/help.js:68
 msgid ""
 "\n"
 "or an FHC command: "
 msgstr ""
 
-#: lib/cmd/fhc/help.js:77
+#: lib/cmd/fhc/help.js:71
 msgid ""
 "\n"
 "Add --help to any command for quick help, or use fhc help <command>."
 msgstr ""
 
-#: lib/cmd/fhc/help.js:82
+#: lib/cmd/fhc/help.js:76
 msgid " <action>"
 msgstr ""
 
-#: lib/cmd/fhc/help.js:83
+#: lib/cmd/fhc/help.js:77
 msgid "Where <action> is one of:"
 msgstr ""
 
-#: lib/cmd/fhc/help.js:94
+#: lib/cmd/fhc/help.js:88
 msgid "No action specified. Usage: \n"
 msgstr ""
 
-#: lib/cmd/fhc/help.js:105
+#: lib/cmd/fhc/help.js:99
 msgid "No usage for this command found"
 msgstr ""
 
-#: lib/cmd/fhc/help.js:165
+#: lib/cmd/fhc/help.js:129
 msgid "Global Options"
 msgstr ""
 


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-21057

# What
Remove Windows feature/options

# Why
Windows feature are not so long supported. 

# How
- Remove windows option/type to build apps
- Remove windows type from UPS commands 
- Update translations via `grunt potupload` task

# Verification Steps
- Run the command `./bin/fhc.js build` and check if the windows options/type will appears

```
cmacedo@camilas-MBP ~/work/fh-fhc (RHMAP-21057) $ ./bin/fhc.js build
Usage:
 fhc build --project=<project> --app=<app> --cloud_app=<cloud_app> [--tag=<tag>]
 --environment=<environment> --destination=<destination> [--version=<version>]
 [--config=<config>] [--privateKeyPass=<privateKeyPass>] [--certpass=<certpass>]
 [--download=<download>] [--bundleId=<bundleId>]
 [--cordova_version=<cordova_version>] [--git-tag=<git-tag>]
 [--git-branch=<git-branch>] [--git-commit=<git-commit>] [--json=<json>]

Options:
  --help                   Show help                                   [boolean]
  --version, -v            Specific to the destination (e.g. Android version
                           4.0).                                       [boolean]
  --project, -p            Unique 24 character GUID of the project.   [required]
  --app, -a                Unique 24 character GUID of the client app which will
                           be built.                                  [required]
  --cloud_app, --ca        Unique 24 character GUID of the cloud app which the
                           client app will connect to.                [required]
  --tag, -t                The name of a connection tag for the cloud app, must
                           be in Semantic Version format, e.g. 0.0.1. See:
                           http://semver.org.
  --environment, -e        The id of a target environment, e.g. dev.  [required]
  --destination, -d        One of: android, iphone, ipad, ios(for universal
                           binary), blackberry                        [required]
  --config, -c             Either 'debug' (default), 'distribution', or
                           'release'.
  --privateKeyPass, --pk   Private key password of the bundleId, only needed for
                           'release' builds.
  --certpass, --cp         Certificate password.
  --download, --dw         Boolean value to inform to download or not the built
                           when it finish.
  --bundleId, -b           The unique bundle identifier of the credential
                           bundle. You can get it using 'fhc credentials list'.
                           Required for all iOS builds.
  --cordova_version, --cv  For specifying which version of Cordova to use.
                           Currently supported: either 2.2 or 3.3. Only valid
                           for Android for now.
  --git-tag, --gt          Long value of URL that you want shorter for the
                           henr.ie URL.
  --git-branch, --gb       The name of the git branch to build, defaults to
                           'master'.
  --git-commit, --gc       The full hash of the commit to build, if not the head
                           of the branch. Must be used with <branch name>.
  --json, -j               Output into json format

Examples:
  fhc build --project=<project>             Build a client <app> of the
  --app=<app-id>                            <project> connect to the <cloud_app>
  --cloud_app=<cloud-app-id> --tag=<tag>    deployed into the <environment>
  --environment=<environment>
  --destination=<destination>
  --version=<version>
  --config=<release|distribution>
  --privateKeyPass=<private-key-password>
  --certpass=<certificate-password>
  --download=<true|false>
  --bundleId=<credential bundle id>
  --cordova_version=<cordova version>
  --git-tag=<tag name>
  --git-branch=<branch name>
  --git-commit=<commit hash>
```


- Run the command `./bin/fhc.js ups variant add` and check if some Win option will appears.

```
cmacedo@camilas-MBP ~/work/fh-fhc (RHMAP-21057) $ ./bin/fhc.js ups variant add
Usage:
 fhc ups variant add --app=<app> --name=<name> --type=<type>
 [--serverKey=<serverKey>] [--senderId=<senderId>] [--production=<production>]
 [--passphrase=<passphrase>] [--certificate=<certificate>] [--json=<json>]

Options:
  --help                 Show help                                     [boolean]
  --version              Show version number                           [boolean]
  --app, -a              Unique 24 character GUID of your application.[required]
  --name, -n             Name of the variant.                         [required]
  --type, -t             Type of the variant. Choose from:
                         - android
                         - ios
                                                                      [required]
  --serverKey, --sk      Server Key to use Android Firebase Cloud Messaging
                         (E.g. AIza5a448c2f31700a466fbc9d33d33942b043a27596)
  --senderId, --si       Sender ID to use Android Firebase Cloud Messaging
                         (E.g.contact@email.com)
  --production, -p       To inform if is a production certificate to use the
                         Apple Push Network. Default value is false.
  --passphrase, --pp     Password of the certificate  to use the Apple Push
                         Network
  --certificate, --cert  Path with the name of the iOS certificate file, *.p12,
                         to use the Apple Push Network.
  --json, -j             Output in json format

Examples:
  fhc ups variant add --app=<appId>         Add Android variant for the <appId>
  --name=<name> --type=android              with the <name>, and <serverKey> and
  --serverKey=<serverKey>                   <senderId>
  --senderId=<senderId>
  fhc ups variant add --app=<appId>         Add Android variant for the <appId>
  --name=<name> --type=ios                  with the <name>, and <production>
  --production=<true|false>                 and <passphrase>
  --passphrase=<passphrase>
  --certificate=<certificate>
```

- Run the command `./bin/fhc.js ups variant delete` and check if some win option will appears. 

```
cmacedo@camilas-MBP ~/work/fh-fhc (RHMAP-21057) $ ./bin/fhc.js ups variant delete
Usage:
 fhc ups variant delete --app=<app> --id=<id> --type=<type> [--json=<json>]

Options:
  --help      Show help                                                [boolean]
  --version   Show version number                                      [boolean]
  --app, -a   Unique 24 character GUID of your application.           [required]
  --id, -i    Variant ID which should be removed. To get this value use $fhc ups
              variant list --app=<app>                                [required]
  --type, -t  Type of the variant. Choose from:
              - android
              - ios
                                                                      [required]
  --json, -j  Output in json format

Examples:
  fhc ups variant delete --app=<appId>      Delete the variant with <id> from
  --id=<id>                                 the <appId>
```

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
