### PR TITLE
Update deps of grunt-zanata-js to fix potupload task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 # Unreleased
 
+## [7.0.2] - Fri Aug 24 2018
+### Change
+- Update the dependency of grunt-zanata-js to fix the failure of potupload task in grunt.
+
 ## [7.0.1] - Tue Ago 15 2018
 ### Change
 - Remove the Blackberry references since it is no so longer supported. 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,709 +4,731 @@
   "dependencies": {
     "abbrev": {
       "version": "1.1.1",
-      "from": "abbrev@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz"
     },
     "ajv": {
       "version": "5.5.2",
-      "from": "ajv@>=5.1.0 <6.0.0",
+      "from": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz"
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "from": "ansi-regex@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
     },
     "asn1": {
       "version": "0.2.3",
-      "from": "asn1@>=0.2.3 <0.3.0",
+      "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
     },
     "assert-plus": {
       "version": "1.0.0",
-      "from": "assert-plus@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
     },
     "async": {
       "version": "0.2.9",
-      "from": "async@0.2.9",
+      "from": "https://registry.npmjs.org/async/-/async-0.2.9.tgz",
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
     },
     "asynckit": {
       "version": "0.4.0",
-      "from": "asynckit@>=0.4.0 <0.5.0",
+      "from": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "from": "aws-sign2@>=0.7.0 <0.8.0",
+      "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz"
     },
     "aws4": {
       "version": "1.7.0",
-      "from": "aws4@>=1.6.0 <2.0.0",
+      "from": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz"
     },
     "balanced-match": {
       "version": "1.0.0",
-      "from": "balanced-match@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
     },
     "block-stream": {
       "version": "0.0.9",
-      "from": "block-stream@*",
+      "from": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
     },
     "boom": {
       "version": "4.3.1",
-      "from": "boom@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz"
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "from": "brace-expansion@>=1.1.7 <2.0.0",
+      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
     },
     "camelcase": {
       "version": "4.1.0",
-      "from": "camelcase@>=4.1.0 <5.0.0",
+      "from": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
     },
     "caseless": {
       "version": "0.12.0",
-      "from": "caseless@>=0.12.0 <0.13.0",
+      "from": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
     },
     "cli-table": {
       "version": "0.3.1",
-      "from": "cli-table@0.3.1",
+      "from": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
       "dependencies": {
         "colors": {
           "version": "1.0.3",
-          "from": "colors@1.0.3",
+          "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
         }
       }
     },
     "cliui": {
       "version": "4.1.0",
-      "from": "cliui@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "from": "ansi-regex@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
-        },
         "strip-ansi": {
           "version": "4.0.0",
-          "from": "strip-ansi@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
         }
       }
     },
     "co": {
       "version": "4.6.0",
-      "from": "co@>=4.6.0 <5.0.0",
+      "from": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
     },
     "code-point-at": {
       "version": "1.1.0",
-      "from": "code-point-at@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
     },
     "combined-stream": {
       "version": "1.0.6",
-      "from": "combined-stream@>=1.0.5 <1.1.0",
+      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz"
     },
     "concat-map": {
       "version": "0.0.1",
-      "from": "concat-map@0.0.1",
+      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
     },
     "core-util-is": {
       "version": "1.0.2",
-      "from": "core-util-is@1.0.2",
+      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "cross-spawn": {
       "version": "5.1.0",
-      "from": "cross-spawn@>=5.0.1 <6.0.0",
+      "from": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz"
     },
     "cryptiles": {
       "version": "3.1.2",
-      "from": "cryptiles@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "dependencies": {
         "boom": {
           "version": "5.2.0",
-          "from": "boom@>=5.0.0 <6.0.0",
+          "from": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz"
         }
       }
     },
     "dashdash": {
       "version": "1.14.1",
-      "from": "dashdash@>=1.12.0 <2.0.0",
+      "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "from": "delayed-stream@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
     },
     "encoding": {
       "version": "0.1.12",
-      "from": "encoding@>=0.1.12 <0.2.0",
+      "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
     },
     "execa": {
       "version": "0.7.0",
-      "from": "execa@>=0.7.0 <0.8.0",
+      "from": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz"
     },
     "extend": {
       "version": "3.0.1",
-      "from": "extend@>=3.0.1 <3.1.0",
+      "from": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
     },
     "extsprintf": {
       "version": "1.3.0",
-      "from": "extsprintf@1.3.0",
+      "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "from": "fast-deep-equal@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz"
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
     },
     "find-up": {
       "version": "3.0.0",
-      "from": "find-up@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz"
     },
     "findit": {
       "version": "2.0.0",
-      "from": "findit@2.0.0",
+      "from": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz"
     },
     "forever-agent": {
       "version": "0.6.1",
-      "from": "forever-agent@>=0.6.1 <0.7.0",
+      "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
     },
     "form-data": {
       "version": "2.3.2",
-      "from": "form-data@>=2.3.1 <2.4.0",
+      "from": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz"
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "from": "fs.realpath@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
     },
     "fstream": {
       "version": "1.0.11",
-      "from": "fstream@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz"
     },
     "get-caller-file": {
       "version": "1.0.2",
-      "from": "get-caller-file@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
     },
     "get-stream": {
       "version": "3.0.0",
-      "from": "get-stream@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz"
     },
     "getpass": {
       "version": "0.1.7",
-      "from": "getpass@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
     },
     "gettext-parser": {
       "version": "1.3.1",
-      "from": "gettext-parser@>=1.1.2 <2.0.0",
+      "from": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.3.1.tgz"
     },
     "glob": {
       "version": "7.1.2",
-      "from": "glob@>=7.0.5 <8.0.0",
+      "from": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
     },
     "graceful-fs": {
       "version": "4.1.11",
-      "from": "graceful-fs@>=4.1.2 <5.0.0",
+      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
     },
     "har-schema": {
       "version": "2.0.0",
-      "from": "har-schema@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz"
     },
     "har-validator": {
       "version": "5.0.3",
-      "from": "har-validator@>=5.0.3 <5.1.0",
+      "from": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz"
     },
     "hawk": {
       "version": "6.0.2",
-      "from": "hawk@>=6.0.2 <6.1.0",
+      "from": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz"
     },
     "hoek": {
       "version": "4.2.1",
-      "from": "hoek@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz"
     },
     "http-signature": {
       "version": "1.2.0",
-      "from": "http-signature@>=1.2.0 <1.3.0",
+      "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz"
     },
     "iconv-lite": {
       "version": "0.4.23",
-      "from": "iconv-lite@>=0.4.13 <0.5.0",
+      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz"
     },
     "inflight": {
       "version": "1.0.6",
-      "from": "inflight@>=1.0.4 <2.0.0",
+      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
     },
     "inherits": {
       "version": "2.0.3",
-      "from": "inherits@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
     },
     "invert-kv": {
       "version": "1.0.0",
-      "from": "invert-kv@>=1.0.0 <2.0.0",
+      "from": "http://npm.skunkhenry.com/invert-kv/-/invert-kv-1.0.0.tgz",
       "resolved": "http://npm.skunkhenry.com/invert-kv/-/invert-kv-1.0.0.tgz"
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
     },
     "is-stream": {
       "version": "1.1.0",
-      "from": "is-stream@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "from": "is-typedarray@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
     },
     "isexe": {
       "version": "2.0.0",
-      "from": "isexe@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
     },
     "isstream": {
       "version": "0.1.2",
-      "from": "isstream@>=0.1.2 <0.2.0",
+      "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "json-schema": {
       "version": "0.2.3",
-      "from": "json-schema@0.2.3",
+      "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
     },
     "json-schema-traverse": {
       "version": "0.3.1",
-      "from": "json-schema-traverse@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz"
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+      "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
     },
     "jsprim": {
       "version": "1.4.1",
-      "from": "jsprim@>=1.2.2 <2.0.0",
+      "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz"
     },
     "lcid": {
       "version": "1.0.0",
-      "from": "lcid@>=1.0.0 <2.0.0",
+      "from": "http://npm.skunkhenry.com/lcid/-/lcid-1.0.0.tgz",
       "resolved": "http://npm.skunkhenry.com/lcid/-/lcid-1.0.0.tgz"
     },
     "locate-path": {
       "version": "3.0.0",
-      "from": "locate-path@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz"
     },
     "lru-cache": {
       "version": "4.1.3",
-      "from": "lru-cache@>=4.0.1 <5.0.0",
+      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz"
     },
     "mem": {
       "version": "1.1.0",
-      "from": "mem@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz"
     },
     "mime-db": {
       "version": "1.33.0",
-      "from": "mime-db@>=1.33.0 <1.34.0",
+      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz"
     },
     "mime-types": {
       "version": "2.1.18",
-      "from": "mime-types@>=2.1.17 <2.2.0",
+      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz"
     },
     "mimic-fn": {
       "version": "1.2.0",
-      "from": "mimic-fn@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz"
     },
     "minimatch": {
       "version": "3.0.4",
-      "from": "minimatch@>=3.0.4 <4.0.0",
+      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
     },
     "minimist": {
       "version": "0.0.8",
-      "from": "minimist@0.0.8",
+      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@>=0.5.0 >=0.0.0 <1.0.0",
+      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
     },
     "moment": {
       "version": "2.22.1",
-      "from": "moment@2.22.1",
+      "from": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz"
     },
     "node-gettext": {
       "version": "1.1.0",
-      "from": "node-gettext@1.1.0",
+      "from": "https://registry.npmjs.org/node-gettext/-/node-gettext-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/node-gettext/-/node-gettext-1.1.0.tgz"
     },
     "nopt": {
       "version": "4.0.1",
-      "from": "nopt@4.0.1",
+      "from": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz"
     },
     "npm-run-path": {
       "version": "2.0.2",
-      "from": "npm-run-path@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz"
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "from": "number-is-nan@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
     },
     "oauth-sign": {
       "version": "0.8.2",
-      "from": "oauth-sign@>=0.8.2 <0.9.0",
+      "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
     },
     "once": {
       "version": "1.4.0",
-      "from": "once@>=1.3.2 <2.0.0",
+      "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
     },
     "os-homedir": {
       "version": "1.0.2",
-      "from": "os-homedir@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
     },
     "os-locale": {
       "version": "2.1.0",
-      "from": "os-locale@2.1.0",
+      "from": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz"
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "from": "os-tmpdir@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
     },
     "osenv": {
       "version": "0.1.5",
-      "from": "osenv@>=0.1.4 <0.2.0",
+      "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz"
     },
     "p-finally": {
       "version": "1.0.0",
-      "from": "p-finally@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz"
     },
     "p-limit": {
       "version": "2.0.0",
-      "from": "p-limit@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz"
     },
     "p-locate": {
       "version": "3.0.0",
-      "from": "p-locate@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz"
     },
     "p-try": {
       "version": "2.0.0",
-      "from": "p-try@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz"
     },
     "path-exists": {
       "version": "3.0.0",
-      "from": "path-exists@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
     },
     "path-key": {
       "version": "2.0.1",
-      "from": "path-key@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
     },
     "performance-now": {
       "version": "2.1.0",
-      "from": "performance-now@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz"
     },
     "progress": {
       "version": "1.1.8",
-      "from": "progress@>=1.1.8 <2.0.0",
+      "from": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
     },
     "pseudomap": {
       "version": "1.0.2",
-      "from": "pseudomap@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
     },
     "punycode": {
       "version": "1.4.1",
-      "from": "punycode@>=1.4.1 <2.0.0",
+      "from": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
     },
     "qrcode-terminal": {
       "version": "0.11.0",
-      "from": "qrcode-terminal@>=0.11.0 <0.12.0",
+      "from": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.11.0.tgz",
       "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.11.0.tgz"
     },
     "qs": {
       "version": "6.5.2",
-      "from": "qs@>=6.5.1 <6.6.0",
+      "from": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz"
     },
     "request": {
       "version": "2.82.0",
-      "from": "request@2.82.0",
+      "from": "https://registry.npmjs.org/request/-/request-2.82.0.tgz",
       "resolved": "https://registry.npmjs.org/request/-/request-2.82.0.tgz"
     },
     "require-directory": {
       "version": "2.1.1",
-      "from": "require-directory@>=2.1.1 <3.0.0",
+      "from": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
     },
     "require-main-filename": {
       "version": "1.0.1",
-      "from": "require-main-filename@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
     },
     "rimraf": {
       "version": "2.6.2",
-      "from": "rimraf@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz"
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "from": "safe-buffer@>=5.1.1 <6.0.0",
+      "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "from": "safer-buffer@>=2.1.2 <3.0.0",
+      "from": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
     },
     "semver": {
       "version": "5.4.1",
-      "from": "semver@5.4.1",
+      "from": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
     },
     "set-blocking": {
       "version": "2.0.0",
-      "from": "set-blocking@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
     },
     "shebang-command": {
       "version": "1.2.0",
-      "from": "shebang-command@>=1.2.0 <2.0.0",
+      "from": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz"
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "from": "shebang-regex@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
     },
     "signal-exit": {
       "version": "3.0.2",
-      "from": "signal-exit@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
     },
     "sntp": {
       "version": "2.1.0",
-      "from": "sntp@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
     },
     "sshpk": {
       "version": "1.14.2",
-      "from": "sshpk@>=1.7.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz"
+      "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "dependencies": {
+        "jsbn": {
+          "version": "0.1.1",
+          "from": "jsbn@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "from": "tweetnacl@>=0.14.0 <0.15.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+        },
+        "ecc-jsbn": {
+          "version": "0.1.2",
+          "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz"
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz"
+        }
+      }
     },
     "string-width": {
       "version": "2.1.1",
-      "from": "string-width@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "from": "ansi-regex@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
-        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "from": "strip-ansi@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
         }
       }
     },
     "stringstream": {
       "version": "0.0.6",
-      "from": "stringstream@>=0.0.5 <0.1.0",
+      "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz"
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "from": "strip-ansi@>=3.0.1 <4.0.0",
+      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
     },
     "strip-eof": {
       "version": "1.0.0",
-      "from": "strip-eof@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz"
     },
     "tabtab": {
       "version": "0.0.2",
-      "from": "tabtab@0.0.2",
+      "from": "https://registry.npmjs.org/tabtab/-/tabtab-0.0.2.tgz",
       "resolved": "https://registry.npmjs.org/tabtab/-/tabtab-0.0.2.tgz"
     },
     "tar": {
       "version": "2.2.1",
-      "from": "tar@2.2.1",
+      "from": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
     },
     "tough-cookie": {
       "version": "2.3.4",
-      "from": "tough-cookie@>=2.3.2 <2.4.0",
+      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz"
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "from": "tunnel-agent@>=0.6.0 <0.7.0",
+      "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
     },
     "underscore": {
       "version": "1.8.3",
-      "from": "underscore@1.8.3",
+      "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     },
     "underscore-deep-extend": {
       "version": "0.0.5",
-      "from": "underscore-deep-extend@0.0.5",
+      "from": "https://registry.npmjs.org/underscore-deep-extend/-/underscore-deep-extend-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/underscore-deep-extend/-/underscore-deep-extend-0.0.5.tgz"
     },
     "uuid": {
       "version": "3.3.2",
-      "from": "uuid@>=3.1.0 <4.0.0",
+      "from": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz"
     },
     "verror": {
       "version": "1.10.0",
-      "from": "verror@1.10.0",
+      "from": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
     },
     "which": {
       "version": "1.3.1",
-      "from": "which@>=1.2.9 <2.0.0",
+      "from": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz"
     },
     "which-module": {
       "version": "2.0.0",
-      "from": "which-module@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz"
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "from": "wrap-ansi@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "dependencies": {
         "string-width": {
           "version": "1.0.2",
-          "from": "string-width@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
         }
       }
     },
     "wrappy": {
       "version": "1.0.2",
-      "from": "wrappy@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
     },
     "xregexp": {
       "version": "4.0.0",
-      "from": "xregexp@4.0.0",
+      "from": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz"
     },
     "y18n": {
       "version": "4.0.0",
-      "from": "y18n@>=3.2.1 <4.0.0||>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz"
     },
     "yallist": {
       "version": "2.1.2",
-      "from": "yallist@>=2.1.2 <3.0.0",
+      "from": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
     },
     "yargs": {
       "version": "12.0.1",
-      "from": "yargs@12.0.1",
+      "from": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
       "dependencies": {
         "decamelize": {
           "version": "2.0.0",
-          "from": "decamelize@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz"
         }
       }
     },
     "yargs-parser": {
       "version": "10.1.0",
-      "from": "yargs-parser@>=10.1.0 <11.0.0",
+      "from": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz"
     }
   }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "7.0.1-BUILD-NUMBER",
+  "version": "7.0.2-BUILD-NUMBER",
   "dependencies": {
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "7.0.1-BUILD-NUMBER",
+  "version": "7.0.2-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "grunt-jsxgettext": "1.1.0",
     "grunt-open": "0.2.3",
     "grunt-shell": "2.1.0",
-    "grunt-zanata-js": "1.3.2",
+    "grunt-zanata-js": "1.4.1",
     "istanbul": "0.4.5",
     "jsxgettext": "0.8.2",
     "load-grunt-tasks": "3.5.2",


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-21472

# What
The task of `grunt potupload` fails.

# Why
This happens due to the changes of the Zanata REST APIs.

# How
newer zanata-js and grunt-zanata-js fixes this issue and just need to update the deps of library for them.

# Verification Steps
run `grunt potupload`


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
