### PR TITLE
Fixed alias for template in fhc services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 # Unreleased
 
+## [7.0.3] - Tue Sep 11 2018
+### Fix
+- Fixed alias for template parameter for fhc services create command.
+
 ## [7.0.2] - Fri Aug 24 2018
 ### Change
 - Update the dependency of grunt-zanata-js to fix the failure of potupload task in grunt.

--- a/lib/cmd/fh3/services/create.js
+++ b/lib/cmd/fh3/services/create.js
@@ -21,7 +21,7 @@ module.exports = {
   'demand' : ['title'],
   'alias' : {
     'title' : 't',
-    'template' : 't',
+    'template' : 'p',
     'env' : 'e',
     0 : 'title',
     1 : 'template',
@@ -29,7 +29,7 @@ module.exports = {
   },
   'describe' : {
     'title' : i18n._('Title of the Service that you want create'),
-    'template' : i18n._('Unique 24 character GUID of the template'),
+    'template' : i18n._('ID of the template, see `fhc templates services`'),
     'env' : i18n._('Unique 24 character GUID of the environment that you want deploy the project after it be created')
   },
   'customCmd' : function(params,cb) {
@@ -49,7 +49,7 @@ module.exports = {
     });
   },'postCmd': function(argv, params, cb) {
     if (params && !argv.json) {
-      return cb(null, util.format(i18n._("Service '%s' create successfully"), params.title));
+      return cb(null, util.format(i18n._("Service '%s' created successfully"), params.title));
     } else {
       return cb(null,params);
     }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "7.0.2-BUILD-NUMBER",
+  "version": "7.0.3-BUILD-NUMBER",
   "dependencies": {
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "7.0.2-BUILD-NUMBER",
+  "version": "7.0.3-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"


### PR DESCRIPTION
# Jira link(s)

No JIRA, I have just found it while doing preliminary testing of fhc before 4.7.0 is cut.

# What

Alias for title and template cannot be the same.

# Why

Because then the input parameters are not processed properly


# How

Fixed by changing the alias for template from 't' to 'p'


# Verification Steps

All these commands should create the service successfully. Preferably use node10 or node8.

fhc services create --title=yourtitle
fhc services create --title=yourtitle-01 --template=new-service
fhc services create -t=yourtitle-03 -p=new-service
fhc services create yourtitle-04 new-service

You can optionally run our fh-art test suite
https://github.com/fheng/fh-art
command to trigger it locally:
grunt test-core:core --prefix yourprefix- --coreusername yourusername --corepassword yourpassword --corehost https://your.rhmap.domain.com


## Checklist:

- [ x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
