### PR TITLE
fix(admin logs syslogs) - Fix command which was missing alias and remove fhc perm validations to allow users check the errors from the backend and knows that they do not have permissions to do some action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## [7.1.3] - Tue Oct 09 2018
+### Fix/Change
+- Add alias to the command fhc admin logs syslogs which was missing
+- Remove the perm validations in the command and allow backend return unauthorized messages
+
 ## [7.1.2] - Tue Oct 12 2018
 ### Change
 - Upgrade request dependency to 2.88.0

--- a/lib/cmd/fh3/admin/domains/check.js
+++ b/lib/cmd/fh3/admin/domains/check.js
@@ -7,7 +7,6 @@ module.exports = {
     cmd : 'fhc admin domains check --domain=<domain>',
     desc : i18n._('Check the domain')}],
   'demand' : ['domain'],
-  'perm' : "cluster/reseller/customer:write",
   'alias' : {
     'domain':'d',
     'json':'j',

--- a/lib/cmd/fh3/admin/domains/create.js
+++ b/lib/cmd/fh3/admin/domains/create.js
@@ -5,7 +5,6 @@ module.exports = {
     cmd : 'fhc admin domains create --name=<name> --type=<type> --theme=<theme> --parent=<parent> ',
     desc : i18n._('Create a domain with the <name>, type<type>, <theme> and <parent>')}],
   'demand' : ['name','type'],
-  'perm' : "cluster/reseller/customer:write",
   'alias' : {
     'name':'n',
     'type':'t',

--- a/lib/cmd/fh3/admin/logs/syslogs.js
+++ b/lib/cmd/fh3/admin/logs/syslogs.js
@@ -15,6 +15,13 @@ module.exports = {
     'numLogEntries': i18n._("The maximum number of log entries returned. Default is 1000."),
     'orderBy': i18n._("The order of entries, by timestamp, to be displayed. The available options are 'first' or 'last'")
   },
+  'alias' : {
+    'requestId' : 'id',
+    'projects' : 'p',
+    'json' : 'j',
+    0 :'requestId',
+    1 :'projects'
+  },
   'orderingParams': {
     'first': 'asc',
     'last': 'desc'

--- a/lib/cmd/fh3/admin/logs/syslogs.js
+++ b/lib/cmd/fh3/admin/logs/syslogs.js
@@ -26,7 +26,6 @@ module.exports = {
     'first': 'asc',
     'last': 'desc'
   },
-  'perm': 'cluster/reseller:read',
   'url': "/api/v2/logs/syslogs",
   'method': 'post',
   'preCmd': function(params, cb) {

--- a/lib/cmd/fh3/admin/status.js
+++ b/lib/cmd/fh3/admin/status.js
@@ -18,7 +18,6 @@ module.exports = {
   'describe' : {
     'json' : i18n._('Output of this command in json format')
   },
-  'perm' : "cluster/reseller/customer:read",
   'url' : '/box/api/status',
   'method' : 'get',
   'postCmd': function(argv, params, cb) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "7.1.2-BUILD-NUMBER",
+  "version": "7.1.3-BUILD-NUMBER",
   "dependencies": {
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "7.1.2-BUILD-NUMBER",
+  "version": "7.1.3-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"


### PR DESCRIPTION
# Jira link(s)

https://issues.jboss.org/browse/RHMAP-21769

# What
- Remove the perm validation in FHC and allow the users see the permissions errors from FH-SUPERCORE. 
- Solving the following error
```
fhc ERR! command "/Users/camilamacedo/.nvm/versions/node/v10.11.0/bin/node" "/Users/camilamacedo/work/fh-fhc/bin/fhc.js" "admin" "logs" "syslogs"
fhc Command executed with error
camilamacedo@Camilas-MBP ~/work/fh-fhc (master) $ ./bin/fhc.js admin logs syslogs
YError: Invalid first argument. Expected object or string or array but received undefined.
    at argumentTypeError (/Users/camilamacedo/work/fh-fhc/node_modules/yargs/lib/argsert.js:65:9)
    at parsed.demanded.forEach (/Users/camilamacedo/work/fh-fhc/node_modules/yargs/lib/argsert.js:38:39)
    at Array.forEach (<anonymous>)
    at argsert (/Users/camilamacedo/work/fh-fhc/node_modules/yargs/lib/argsert.js:34:21)
    at Object.Yargs.self.alias (/Users/camilamacedo/work/fh-fhc/node_modules/yargs/yargs.js:247:5)
    at _setupForValidation (/Users/camilamacedo/work/fh-fhc/lib/utils/args.js:89:4)
    at Object.exports.validate (/Users/camilamacedo/work/fh-fhc/lib/utils/args.js:21:3)
    at EventEmitter.fhc.applyCommandFunction (/Users/camilamacedo/work/fh-fhc/lib/fhc.js:135:23)
    at /Users/camilamacedo/work/fh-fhc/bin/fhc.js:15:19
    at /Users/camilamacedo/work/fh-fhc/lib/fhc.js:97:12
Usage:
 fhc admin logs syslogs --requestId=<requestId> --projects=<projects>
 [--numLogEntries=<numLogEntries>] [--orderBy=<orderBy>]
```


# Why

- The errors is because the command was missing alias
- The perm was removed for 2 reasons: 
** shows not working as should be
** Ii is a better approach customers see that don't have the permission than do not found the command. 

**It is important to highlight that by default all commands work in this way, the roles valdiation is made in the backend and just in this few cases the FHC was using the "perm".**

# How
- Remove the perm validation of all commands which are using it which is in the` `total 4`. 
- Add an alias to the command

# Verification Steps
- Run the command ./bin/fhc.js admin status and see it returning the result for a reseller user

```
camilamacedo@Camilas-MBP ~/work/fh-fhc (RHMAP-21769) $ ./bin/fhc.js admin status
┌────────┬────┐
│ Status │ ok │
├────────┼────┤
│ amqp   │ ok │
├────────┼────┤
│ db     │ ok │
├────────┼────┤
│ cache  │ ok │
├────────┼────┤
│ git    │ ok │
└────────┴────┘

```

- Run the command which follows with  a user with the resseler permition to read. 

```
camilamacedo@Camilas-MBP ~/work/fh-fhc (RHMAP-21769) $ ./bin/fhc.js admin domains create --name=test --type=developer --theme=test --parent=test
fhc ERR! Error: Error - not 2xx status code. (401)
fhc ERR! {"message":"unauthorized","status":"error","result":{"reason":"permissions","perm":"cluster/reseller/customer:write"}}
fhc ERR! Request ID:  8b5b949a-767f-4ee3-bb25-b9db0282a034
fhc ERR! 
fhc ERR! System Darwin 17.7.0
fhc ERR! command "/Users/camilamacedo/.nvm/versions/node/v6.14.4/bin/node" "/Users/camilamacedo/work/fh-fhc/bin/fhc.js" "admin" "domains" "create" "--name=test" "--type=developer" "--theme=test" "--parent=test"
fhc Command executed with error
camilamacedo@Camilas-MBP ~/work/fh-fhc (RHMAP-21769) $ 

```

- With a reseller user/domain run the command "./bin/fhc.js admin logs syslogs". Following the expected result.

```
camilamacedo@Camilas-MBP ~/work/fh-fhc (master) $ ./bin/fhc.js admin logs syslogs
Usage:
 fhc admin logs syslogs --requestId=<requestId> --projects=<projects>
 [--numLogEntries=<numLogEntries>] [--orderBy=<orderBy>]

Options:
  --help             Show help                                         [boolean]
  --version          Show version number                               [boolean]
  --requestId, --id  A request ID to search for.                      [required]
  --projects, -p     A comma-separated list of project names to search for logs
                     in.                                              [required]
  --numLogEntries    The maximum number of log entries returned. Default is
                     1000.
  --orderBy          The order of entries, by timestamp, to be displayed. The
                     available options are 'first' or 'last'

Examples:
  fhc admin syslogs                         Searching for log entries associated
  --requestId="07401646-b55e-4b9f-a181-c42  with request ID:
  f2fcbfd17" --projects="core,mbaas"        07401646-b55e-4b9f-a181-c42f2fcbfd17

Missing required arguments: requestId, projects
fhc ERR! YError: Missing required arguments: requestId, projects
fhc ERR! 
fhc ERR! System Darwin 17.7.0
fhc ERR! command "/Users/camilamacedo/.nvm/versions/node/v10.11.0/bin/node" "/Users/camilamacedo/work/fh-fhc/bin/fhc.js" "admin" "logs" "syslogs"
fhc Command executed with error
camilamacedo@Camilas-MBP ~/work/fh-fhc (master) $ 

``` 

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
