### PR TITLE
Fix publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 # Unreleased
 
+## [7.1.1] - Tue Oct 12 2018
+### Fix
+- Dependency required for production is missing
+
 ## [7.1.0] - Tue Sep 27 2018
 ### Change
 - Add deprecate notice for build command since it will not so long supported. For more details, please see [here](https://redhatmobilestatus.com/2018/09/26/immediate-deprecation-of-the-rhmap-client-binary-build-service-build-farm/).
@@ -21,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [7.0.1] - Tue Ago 15 2018
 ### Change
-- Remove the Blackberry references since it is no so longer supported. 
+- Remove the Blackberry references since it is no so longer supported.
 
 ## [7.0.0] - Tue Jul 17 2018
 ### Change
@@ -99,7 +103,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated readme
 
 
-## [4.1.2] - 
+## [4.1.2] -
 ### Added
 - added tests
 
@@ -107,32 +111,32 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - change to not include app info by default
 
 
-## [4.1.1] - 
+## [4.1.1] -
 ### Changed
 - changed so fhc requires just the branchname rather than /refs/head/<Branchname>
 
 
-## [4.1.0] - 
+## [4.1.0] -
 ### Removed
 - Removes command completion
 
 
-## [4.0.6] - 
+## [4.0.6] -
 ### Changed
 - Changed proxy timeout to millicore
 
 
-## [4.0.5] - 
+## [4.0.5] -
 ### Changed
 - Moved request implementations defined in common.js to command files.
 
 
-## [4.0.4] - 
+## [4.0.4] -
 ### Changed
 - Replaced deprecated `util.pump`
 
 
-## [4.0.3] - 
+## [4.0.3] -
 ### Changed
 - updated dependencies:
 ```git
@@ -221,7 +225,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added unit tests
 
 ### Changed
-- Change the cmd fhc admin-users to follow the V3 standard 
+- Change the cmd fhc admin-users to follow the V3 standard
 
 
 ## [3.1.2] - Wed Sep 13 18:55:44 2017 +0100
@@ -297,7 +301,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [3.0.0] - Fri Aug 11 11:53:44 2017 +0100
-__*note*__ breaking API changes introduced in v3 of fh-fhc, where support for v2 commands are removed  
+__*note*__ breaking API changes introduced in v3 of fh-fhc, where support for v2 commands are removed
 ### Added
 - Added unit tests
 
@@ -382,7 +386,7 @@ __*note*__ breaking API changes introduced in v3 of fh-fhc, where support for v2
 
 
 ## [2.18.0] - Tue Jul 25 11:19:43 2017 +0200
-__*note:*__ v2.18.0 was a large minor version update that involved a lot of changes to add various commands that meet v3 standards, along with accompanying unit tests. In addition files CRUDL commands were removed, support for versions of node >=4.4 was enabled, and linting support was added.  
+__*note:*__ v2.18.0 was a large minor version update that involved a lot of changes to add various commands that meet v3 standards, along with accompanying unit tests. In addition files CRUDL commands were removed, support for versions of node >=4.4 was enabled, and linting support was added.
 ### Added
 - Adds verification for environment ids
 - Adds eslint file containing rules that don't throw any errors (uses grunt-eslint)
@@ -433,7 +437,7 @@ __*note:*__ v2.18.0 was a large minor version update that involved a lot of chan
 - Fixes where re-deployment via fhc get stuck with incorrect runtime specified
 - Add command `fhc artifacts` to V3 standard
 - Change the cmd user to follow the V3 standard
-- Change the cmd -v update to follow the V3 standard 
+- Change the cmd -v update to follow the V3 standard
 - Change the cmd shorturl to follow the V3 standard
 - Change the cmd stats to follow the V3 standard
 - Change the cmd call to follow the V3 standard
@@ -502,7 +506,7 @@ __*note:*__ v2.18.0 was a large minor version update that involved a lot of chan
 - Updated request payload to allow import of cloud app from git repo
 - Allows type MBAAS for fhc policies create. Updated usage also
 - Fixes validation on admin-policies args length and passing correct args to update function
-- Fixes zanata grunt task that previously broke the build 
+- Fixes zanata grunt task that previously broke the build
 - Defaults to HEAD if user doesn't pass a git hash
 - App stage - default to master and update usage to show default
 - Fixes error where `fhc clusterprops` appears as a subcommand of the `error` command

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -94,15 +94,15 @@
       "from": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
       "dependencies": {
-        "strip-ansi": {
-          "version": "4.0.0",
-          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
         }
       }
     },
@@ -115,6 +115,11 @@
       "version": "1.1.0",
       "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+    },
+    "colors": {
+      "version": "1.3.2",
+      "from": "colors@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz"
     },
     "combined-stream": {
       "version": "1.0.6",
@@ -573,25 +578,29 @@
       "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "dependencies": {
-        "jsbn": {
-          "version": "0.1.1",
-          "from": "jsbn@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "from": "tweetnacl@>=0.14.0 <0.15.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+          "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.2",
           "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+          "optional": true
         },
-        "bcrypt-pbkdf": {
-          "version": "1.0.2",
-          "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz"
+        "jsbn": {
+          "version": "0.1.1",
+          "from": "jsbn@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "optional": true
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "from": "tweetnacl@>=0.14.0 <0.15.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "optional": true
         }
       }
     },
@@ -600,6 +609,11 @@
       "from": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -609,11 +623,6 @@
           "version": "4.0.0",
           "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "7.1.0-BUILD-NUMBER",
+  "version": "7.1.1-BUILD-NUMBER",
   "dependencies": {
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "7.1.0-BUILD-NUMBER",
+  "version": "7.1.1-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "async": "0.2.9",
     "cli-table": "0.3.1",
+    "colors": "^1.3.2",
     "findit": "2.0.0",
     "moment": "2.22.1",
     "node-gettext": "1.1.0",


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-21483

# What
Fix the following issue with the production version which appears after install via $sudo npm install fh-fhc -g.


 ```
/Users/camilamacedo/.nvm/versions/node/v6.14.4/lib
└── fh-fhc@7.1.0-1 

camilamacedo@Camilas-MacBook-Pro ~ $ fhc
module.js:478
throw err;
^

Error: Cannot find module 'colors'
at Function.Module._resolveFilename (module.js:476:15)
at Function.Module._load (module.js:424:25)
at Module.require (module.js:504:17)
at require (internal/module.js:20:19)
at Object.<anonymous> (/Users/camilamacedo/.nvm/versions/node/v6.14.4/lib/node_modules/fh-fhc/lib/fhc.js:3:14)
at Module._compile (module.js:577:32)
at Object.Module._extensions..js (module.js:586:10)
at Module.load (module.js:494:32)
at tryModuleLoad (module.js:453:12)
at Function.Module._load (module.js:445:3)
camilamacedo@Camilas-MacBook-Pro ~ $ 
```

# Why
The dep colour is not declared in the prod dependencies. It was not faced before because instead of it be published as the other libs was used the version generated by Jenkins which contains the lib because was installed via npm install and not npm install --production as it should be.

# How
add the lib in the dep by the manager

# Verification Steps
- Remove the current npm modules installed ( rm -rf node_modules )
- Run `npm install --production`
- Run /bin/fhc.js and it needs to work. 

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
