### PR TITLE
RHMAP-21897: Add create connections command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## [7.2.0] - Tue Nov 13 2018
+- Add new commmand to create connections ($fhc connections create)
+
 ## [7.1.4] - Tue Nov 13 2018
 - Fix: Unable to run grunt task test
 

--- a/lib/cmd/fh3/connections/create.js
+++ b/lib/cmd/fh3/connections/create.js
@@ -1,0 +1,75 @@
+/* globals i18n */
+var common = require("../../../common");
+var fhreq = require("../../../utils/request");
+
+module.exports = {
+  'desc' : i18n._('Create connections'),
+  'examples' :
+  [{
+    cmd : 'fhc connections create --client=<client> --cloud=<cloud> --type=<type> --env=<env> --project=<project> --connection=<connection>',
+    desc : i18n._('Create the <connection> for the <client> with the <type> and the <cloud> from the <project> deployed on the <env>')
+  },{
+    cmd : 'fhc connections create --client=<client> --cloud=<cloud> --type=<type> --env=<env> --project=<project>',
+    desc : i18n._('Create a a new sequencially connection for the <client> with the <type> and the <cloud> from the <project> deployed on the <env>')
+  }
+  ],
+  'demand' : ['client','cloud','type','env','project'],
+  'alias' : {
+    'client' : 'cli',
+    'cloud' : 'clo',
+    'type' : 't',
+    'env' : 'e',
+    'project' : 'p',
+    'connection' : 'c',
+    'json': 'j',
+    0 : 'client',
+    1 : 'cloud',
+    2 : 'type',
+    3 : 'env',
+    4 : 'project',
+    5 : 'connection'
+  },
+  'describe' : {
+    'client' : i18n._('Unique 24 character GUID of the project'),
+    'cloud' : i18n._('Unique 24 character GUID of the connection'),
+    'type' : i18n._('"Client app type : [android, ios, html5]"'),
+    'env' : i18n._('Unique 24 character GUID of the cloud application'),
+    'project' : i18n._('Unique 24 character GUID of the cloud application'),
+    'connection' : i18n._('Connection Tags must be in Semantic Version format, e.g. 0.0.1. See: http://semver.org'),
+    'json' : i18n._("Output in json format")
+  },
+  'customCmd' : function(params,cb) {
+    var url = '/box/api/connections/' ;
+    params.type = params.type.toLowerCase();
+    if ( params.type !== 'android' && params.type !== 'ios' && params.type !== 'html5' ) {
+      return cb(i18n._('Invalid type of client app : ' + params.type));
+    }
+    var payload =  {
+      clientApp: params.client,
+      cloudApp: params.cloud,
+      destination: params.type,
+      environment: params.env,
+      project: params.project,
+      status: "ACTIVE"
+    };
+
+    if (params.connection) {
+      payload.tag = params.connection;
+    }
+
+    fhreq.POST(fhreq.getFeedHenryUrl(), url, payload, function(err, con, raw, response) {
+      if (err) {
+        return cb(err);
+      }
+      if (response.statusCode !== 201) {
+        return cb(raw);
+      }
+      if (!params.json) {
+        var headers = ['Id', 'Environment', 'Connection Tag', 'Platform', 'Client App', 'Cloud App', 'Build Type', 'Status'];
+        var fields = ['guid', 'environment', 'tag', 'destination', 'clientApp', 'cloudApp', 'build', 'status'];
+        con._table = common.createTableFromArray(headers, fields, [con]);
+      }
+      return cb(null, con);
+    });
+  }
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-fhc",
-  "version": "7.1.4-BUILD-NUMBER",
+  "version": "7.2.0-BUILD-NUMBER",
   "dependencies": {
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-fhc",
   "description": "A Command Line Interface for FeedHenry",
-  "version": "7.1.4-BUILD-NUMBER",
+  "version": "7.2.0-BUILD-NUMBER",
   "_minPlatformVersion": "3.11.0",
   "keywords": [
     "feedhenry"


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-21897


# What
Add command to create connections


# Why
In order to be helpful when the BF be deprecated



# How
New command to use the same REST API used by RHMAP studio

# Verification Steps
### Check if the new command will be listed.

```
$ ./bin/fhc.js connections
No action specified. Usage: 
fhc connections <action>
Where <action> is one of:
  create             	Create connections
  list               	List connections
  read               	Read a connection
  update             	Update connections
```

### Check the required options validation and descriptions.

 ```
./bin/fhc.js connections create
Usage:
 fhc connections create --client=<client> --cloud=<cloud> --type=<type>
 --env=<env> --project=<project> [--connection=<connection>] [--json=<json>]

Options:
  --help            Show help                                          [boolean]
  --version         Show version number                                [boolean]
  --client, --cli   Unique 24 character GUID of the project           [required]
  --cloud, --clo    Unique 24 character GUID of the connection        [required]
  --type, -t        "Client app type : [android, ios, html5]"       [required]
  --env, -e         Unique 24 character GUID of the cloud application [required]
  --project, -p     Unique 24 character GUID of the cloud application [required]
  --connection, -c  Connection Tags must be in Semantic Version format, e.g.
                    0.0.1. See: http://semver.org
  --json, -j        Output in json format

Examples:
  fhc connections create --client=<client>  Create the <connection> for the
  --cloud=<cloud> --type=<type>             <client> with the <type> and the
  --env=<env> --project=<project>           <cloud> from the <project> deployed
  --connection=<connection>                 on the <env>
  fhc connections create --client=<client>  Create a a new sequencially
  --cloud=<cloud> --type=<type>             connection for the <client> with the
  --env=<env> --project=<project>           <type> and the <cloud> from the
                                            <project> deployed on the <env>

Missing required arguments: client, cloud, type, env, project
fhc ERR! YError: Missing required arguments: client, cloud, type, env, project
fhc ERR! 
fhc ERR! System Darwin 18.0.0
fhc ERR! command "/Users/camilamacedo/.nvm/versions/node/v6.14.4/bin/node" "/Users/camilamacedo/work/fh-fhc/bin/fhc.js" "connections" "create"
fhc Command executed with error

```

### Create a new connection for Cordova without inform the value
E.g ` ./bin/fhc.js connections create --cloud=gf5i6x74opqkycntbiykivei --client=gf5i6x6k7ypbzrnol6ynvvqz --env=dev --type=html5 --project=gf5i6xy4lgnwuyzlpedrz7t2`

<img width="1237" alt="screenshot 2018-11-12 at 10 35 22" src="https://user-images.githubusercontent.com/7708031/48342097-b73bc380-e666-11e8-926d-22c24ce8284f.png">

### Create a new connection for Cordova by informing a tag

E.g ` ./bin/fhc.js connections create --cloud=gf5i6x74opqkycntbiykivei --client=gf5i6x6k7ypbzrnol6ynvvqz --env=dev --type=html5 --project=gf5i6xy4lgnwuyzlpedrz7t2 --connection=1.0.0`

<img width="1235" alt="screenshot 2018-11-12 at 10 38 26" src="https://user-images.githubusercontent.com/7708031/48342270-1ef20e80-e667-11e8-8495-f82ab7f13675.png">

### Use the --json parameter to check the result in this format.

```
{
  "cloudAppName": null,
  "clientAppName": null,
  "environment": "dev",
  "tag": "1.0.2",
  "domain": "testing",
  "destination": "html5",
  "status": "ACTIVE",
  "statusText": "",
  "cloudApp": "gf5i6x74opqkycntbiykivei",
  "clientApp": "gf5i6x6k7ypbzrnol6ynvvqz",
  "project": "gf5i6xy4lgnwuyzlpedrz7t2",
  "build": "",
  "businessObject": "cluster/reseller/customer/domain/project/connection",
  "clientVersion": 0,
  "guid": "mj7hzv2np6xfkbt67lo66qhj",
  "sysOwner": "u4hsyksna2xvc27n2a4as46j",
  "sysVersion": 0,
  "sysModified": 1542019149803,
  "sysCreated": 1542019149802,
  "sysGroupFlags": 65567,
  "sysGroupList": ""
}
```
## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
